### PR TITLE
Cvode refactor in haskell

### DIFF
--- a/hmatrix-sundials.cabal
+++ b/hmatrix-sundials.cabal
@@ -18,11 +18,7 @@ flag debug
 
 library
   build-depends:       base >=4.10,
-                       inline-c >=0.6,
                        vector >=0.12,
-                       template-haskell >=2.12,
-                       containers >=0.5,
-                       split >=0.2,
                        hmatrix>=0.18,
                        deepseq,
                        mtl,
@@ -53,7 +49,6 @@ library
                        RecordWildCards
                        NamedFieldPuns
                        ScopedTypeVariables
-                       TemplateHaskell
                        QuasiQuotes
                        KindSignatures
                        TypeOperators
@@ -65,7 +60,7 @@ library
                        DeriveGeneric
                        DeriveAnyClass
                        OverloadedStrings
-  ghc-options:         -Wall
+  ghc-options:         -Wall -Wunused-packages
   if flag(debug)
     -- _GNU_SOURCE is needed for asprintf
     cpp-options: -DENABLE_DEBUG -D_GNU_SOURCE

--- a/src/Numeric/Sundials/ARKode.hs
+++ b/src/Numeric/Sundials/ARKode.hs
@@ -1,499 +1,793 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
 -- |
 -- Solution of ordinary differential equation (ODE) initial value problems.
 -- See <https://computation.llnl.gov/projects/sundials/sundials-software> for more detail.
 module Numeric.Sundials.ARKode
-  ( ARKMethod(..)
-  , solveC
-  ) where
+  ( ARKMethod (..),
+    solveC,
+  )
+where
 
-import qualified Language.C.Inline as C
+import Control.Exception
+import Control.Monad (when)
+import Control.Monad.State
+import Data.Bool
+import Data.Maybe (fromMaybe)
 import qualified Data.Vector.Storable as VS
-import Foreign.C.Types
-import GHC.Prim
+import qualified Data.Vector.Storable.Mutable as VSM
+import Data.Void
+import Foreign
+import Foreign.C
 import GHC.Generics
+import GHC.Prim
+import GHC.Stack
 import Katip
-import Foreign.Ptr
-
-import Numeric.Sundials.Foreign
 import Numeric.Sundials.Common
-
-C.context (C.baseCtx <> C.vecCtx <> C.funCtx <> sunCtx)
-
-C.include "<stdlib.h>"
-C.include "<stdio.h>"
-C.include "<string.h>"
-C.include "<math.h>"
-C.include "<arkode/arkode.h>"
-C.include "<arkode/arkode_ls.h>"
-C.include "<arkode/arkode_arkstep.h>"
-C.include "<nvector/nvector_serial.h>"
-C.include "<sunmatrix/sunmatrix_dense.h>"
-C.include "<sunlinsol/sunlinsol_dense.h>"
-C.include "<sunlinsol/sunlinsol_klu.h>"
-C.include "<sundials/sundials_types.h>"
-C.include "<sundials/sundials_types_deprecated.h>"
-C.include "<sundials/sundials_math.h>"
-C.include "../../helpers.h"
+import Numeric.Sundials.Foreign
+import Text.Printf (printf)
 
 -- | Available methods for ARKode
-data ARKMethod = SDIRK_2_1_2
-               | BILLINGTON_3_3_2
-               | TRBDF2_3_3_2
-               | KVAERNO_4_2_3
-               | ARK324L2SA_DIRK_4_2_3
-               | CASH_5_2_4
-               | CASH_5_3_4
-               | SDIRK_5_3_4
-               | KVAERNO_5_3_4
-               | ARK436L2SA_DIRK_6_3_4
-               | KVAERNO_7_4_5
-               | ARK548L2SA_DIRK_8_4_5
-               | HEUN_EULER_2_1_2
-               | BOGACKI_SHAMPINE_4_2_3
-               | ARK324L2SA_ERK_4_2_3
-               | ZONNEVELD_5_3_4
-               | ARK436L2SA_ERK_6_3_4
-               | SAYFY_ABURUB_6_3_4
-               | CASH_KARP_6_4_5
-               | FEHLBERG_6_4_5
-               | DORMAND_PRINCE_7_4_5
-               | ARK548L2SA_ERK_8_4_5
-               | VERNER_8_5_6
-               | FEHLBERG_13_7_8
+data ARKMethod
+  = SDIRK_2_1_2
+  | BILLINGTON_3_3_2
+  | TRBDF2_3_3_2
+  | KVAERNO_4_2_3
+  | ARK324L2SA_DIRK_4_2_3
+  | CASH_5_2_4
+  | CASH_5_3_4
+  | SDIRK_5_3_4
+  | KVAERNO_5_3_4
+  | ARK436L2SA_DIRK_6_3_4
+  | KVAERNO_7_4_5
+  | ARK548L2SA_DIRK_8_4_5
+  | HEUN_EULER_2_1_2
+  | BOGACKI_SHAMPINE_4_2_3
+  | ARK324L2SA_ERK_4_2_3
+  | ZONNEVELD_5_3_4
+  | ARK436L2SA_ERK_6_3_4
+  | SAYFY_ABURUB_6_3_4
+  | CASH_KARP_6_4_5
+  | FEHLBERG_6_4_5
+  | DORMAND_PRINCE_7_4_5
+  | ARK548L2SA_ERK_8_4_5
+  | VERNER_8_5_6
+  | FEHLBERG_13_7_8
   deriving (Eq, Ord, Show, Read, Generic, Bounded, Enum)
 
 instance IsMethod ARKMethod where
-  methodToInt SDIRK_2_1_2             = sDIRK_2_1_2
-  methodToInt BILLINGTON_3_3_2        = bILLINGTON_3_3_2
-  methodToInt TRBDF2_3_3_2            = tRBDF2_3_3_2
-  methodToInt KVAERNO_4_2_3           = kVAERNO_4_2_3
-  methodToInt ARK324L2SA_DIRK_4_2_3   = aRK324L2SA_DIRK_4_2_3
-  methodToInt CASH_5_2_4              = cASH_5_2_4
-  methodToInt CASH_5_3_4              = cASH_5_3_4
-  methodToInt SDIRK_5_3_4             = sDIRK_5_3_4
-  methodToInt KVAERNO_5_3_4           = kVAERNO_5_3_4
-  methodToInt ARK436L2SA_DIRK_6_3_4   = aRK436L2SA_DIRK_6_3_4
-  methodToInt KVAERNO_7_4_5           = kVAERNO_7_4_5
-  methodToInt ARK548L2SA_DIRK_8_4_5   = aRK548L2SA_DIRK_8_4_5
-  methodToInt HEUN_EULER_2_1_2        = hEUN_EULER_2_1_2
-  methodToInt BOGACKI_SHAMPINE_4_2_3  = bOGACKI_SHAMPINE_4_2_3
-  methodToInt ARK324L2SA_ERK_4_2_3    = aRK324L2SA_ERK_4_2_3
-  methodToInt ZONNEVELD_5_3_4         = zONNEVELD_5_3_4
-  methodToInt ARK436L2SA_ERK_6_3_4    = aRK436L2SA_ERK_6_3_4
-  methodToInt SAYFY_ABURUB_6_3_4      = sAYFY_ABURUB_6_3_4
-  methodToInt CASH_KARP_6_4_5         = cASH_KARP_6_4_5
-  methodToInt FEHLBERG_6_4_5          = fEHLBERG_6_4_5
-  methodToInt DORMAND_PRINCE_7_4_5    = dORMAND_PRINCE_7_4_5
-  methodToInt ARK548L2SA_ERK_8_4_5    = aRK548L2SA_ERK_8_4_5
-  methodToInt VERNER_8_5_6            = vERNER_8_5_6
-  methodToInt FEHLBERG_13_7_8         = fEHLBERG_13_7_8
+  methodToInt SDIRK_2_1_2 = sDIRK_2_1_2
+  methodToInt BILLINGTON_3_3_2 = bILLINGTON_3_3_2
+  methodToInt TRBDF2_3_3_2 = tRBDF2_3_3_2
+  methodToInt KVAERNO_4_2_3 = kVAERNO_4_2_3
+  methodToInt ARK324L2SA_DIRK_4_2_3 = aRK324L2SA_DIRK_4_2_3
+  methodToInt CASH_5_2_4 = cASH_5_2_4
+  methodToInt CASH_5_3_4 = cASH_5_3_4
+  methodToInt SDIRK_5_3_4 = sDIRK_5_3_4
+  methodToInt KVAERNO_5_3_4 = kVAERNO_5_3_4
+  methodToInt ARK436L2SA_DIRK_6_3_4 = aRK436L2SA_DIRK_6_3_4
+  methodToInt KVAERNO_7_4_5 = kVAERNO_7_4_5
+  methodToInt ARK548L2SA_DIRK_8_4_5 = aRK548L2SA_DIRK_8_4_5
+  methodToInt HEUN_EULER_2_1_2 = hEUN_EULER_2_1_2
+  methodToInt BOGACKI_SHAMPINE_4_2_3 = bOGACKI_SHAMPINE_4_2_3
+  methodToInt ARK324L2SA_ERK_4_2_3 = aRK324L2SA_ERK_4_2_3
+  methodToInt ZONNEVELD_5_3_4 = zONNEVELD_5_3_4
+  methodToInt ARK436L2SA_ERK_6_3_4 = aRK436L2SA_ERK_6_3_4
+  methodToInt SAYFY_ABURUB_6_3_4 = sAYFY_ABURUB_6_3_4
+  methodToInt CASH_KARP_6_4_5 = cASH_KARP_6_4_5
+  methodToInt FEHLBERG_6_4_5 = fEHLBERG_6_4_5
+  methodToInt DORMAND_PRINCE_7_4_5 = dORMAND_PRINCE_7_4_5
+  methodToInt ARK548L2SA_ERK_8_4_5 = aRK548L2SA_ERK_8_4_5
+  methodToInt VERNER_8_5_6 = vERNER_8_5_6
+  methodToInt FEHLBERG_13_7_8 = fEHLBERG_13_7_8
 
   methodType method =
     if methodToInt method < mIN_DIRK_NUM
       then Explicit
       else Implicit
 
+-- Tries to copy the previous semantic in C when we had:
+data ReturnCode
+  = -- return, with error code, skipping finish (diagnostics and cleanup)
+    ReturnCode Int
+  | -- return with log message, skipping finish (diags and cleanup)
+    ReturnCodeWithMessage String Int
+  | -- "goto" finish (do diag and cleanup)
+    Finish LoopState
+  | -- break the loop, hence go to finish (do diag and cleanup)
+    Break LoopState
+  deriving (Exception, Show)
+
+-- | The loop state, most could be just carried by recursive function call, but
+-- the C semantic was kinda interleaved, so doing that for now.
+data LoopState = LoopState
+  { -- output_ind tracks the current row into the c_output_mat matrix.
+    -- if differs from input_ind because of the extra rows corresponding to events.
+    output_ind :: Int,
+    -- input_ind tracks the current index into the c_sol_time array
+    input_ind :: Int,
+    -- event_ind tracks the current event number
+    event_ind :: Int,
+    t_start :: CDouble
+  }
+  deriving (Show)
+
+foreign import ccall "wrapper"
+  mkReport :: ReportErrorFnNew -> IO (FunPtr ReportErrorFnNew)
+
 solveC :: Ptr CInt -> CConsts -> CVars (VS.MVector RealWorld) -> LogEnv -> IO CInt
-solveC ptrStop CConsts{..} CVars{..} log_env =
-  let
-    report_error = reportErrorWithKatip log_env
-    report_error_new_api = wrapErrorNewApi (reportErrorWithKatip log_env)
-  in do
-  [C.block| int {
-  /* general problem variables */
+solveC _ptrStop CConsts {..} CVars {..} log_env =
+  let report_error_new_api = wrapErrorNewApi (reportErrorWithKatip log_env)
+      debug :: String -> StateT LoopState IO ()
+      debug _s = do
+        -- This SPAMs the logging system with a lot of informations, so we do
+        -- not enable it by default
+        -- Just comment in/out this line for now, we'll think about a nicer solution later
+        -- liftIO (debugMsgWithKatip log_env s)
+        pure ()
+   in do
+        -- Allocate the error reporting callback
+        bracket (mkReport report_error_new_api) freeHaskellFunPtr $ \c_report_error -> do
+          withSUNContext $ \sunctx -> do
+            let init_loop =
+                  ( LoopState
+                      { -- /* input_ind tracks the current index into the c_sol_time array */
+                        input_ind = 1,
+                        -- /* output_ind tracks the current row into the c_output_mat matrix.
+                        --    If differs from input_ind because of the extra rows corresponding to events. */
+                        output_ind = 1,
+                        -- /* event_ind tracks the current event number */
+                        event_ind = 0,
+                        -- /* t_start tracks the starting point of the integration in order to detect
+                        --    empty integration interval and avoid a potential infinite loop;
+                        --    see Note [CV_TOO_CLOSE]. Unlike T0, t_start is updated every time we
+                        --    restart the solving after handling (or not) an event, or emitting
+                        --    a requested time point.
+                        --    Why not just look for the last recorded time in c_output_mat? Because
+                        --    an event may have eventRecord = False and not be present there.
+                        -- \*/
+                        t_start = t0
+                      }
+                  )
 
-  int flag;                  /* reusable error-checking flag                 */
-  int retval = ARK_SUCCESS;
+                t0 = fromMaybe (error "no t0") $ c_sol_time VS.!? 0
 
-  int i, j;                  /* reusable loop indices                        */
-  N_Vector y = NULL;         /* empty vector for storing solution            */
-  N_Vector tv = NULL;        /* empty vector for storing absolute tolerances */
+            -- /* We need to update c_n_rows every time we update output_ind because
+            --    of the possibility of early return (in which case we still need to assemble
+            --    the partial results matrix). We could even work with c_n_rows only and ditch
+            --    output_ind, but the inline-c expression is quite verbose, and output_ind is
+            --    more convenient to use in index calculations.
+            -- \*/
+            VSM.write c_n_rows 0 (fromIntegral init_loop.output_ind)
 
-  SUNMatrix A = NULL;        /* empty matrix for linear solver               */
-  SUNLinearSolver LS = NULL; /* empty linear solver object                   */
-  void *arkode_mem = NULL;   /* empty ARKode memory structure                */
-  realtype t;
-  long int nst, nst_a, nfe, nfi, nsetups, nje, nfeLS, nni, ncfn, netf;
-  SUNContext sunctx;
+            -- /* general problem parameters */
 
-  SUNContext_Create(SUN_COMM_NULL, &sunctx);
+            -- /* Initialize data structures */
 
-  /* input_ind tracks the current index into the c_sol_time array */
-  int input_ind = 1;
-  /* output_ind tracks the current row into the c_output_mat matrix.
-     If differs from input_ind because of the extra rows corresponding to events. */
-  int output_ind = 1;
-  /* We need to update c_n_rows every time we update output_ind because
-     of the possibility of early return (in which case we still need to assemble
-     the partial results matrix). We could even work with c_n_rows only and ditch
-     output_ind, but the inline-c expression is quite verbose, and output_ind is
-     more convenient to use in index calculations.
-  */
-  ($vec-ptr:(int *c_n_rows))[0] = output_ind;
-  /* event_ind tracks the current event number */
-  int event_ind = 0;
+            -- /* Initialize odeMaxEventsReached to False */
+            VSM.write c_diagnostics 10 0
+            let implicit = c_method >= ARKODE_MIN_DIRK_NUM
 
-  /* general problem parameters */
+            -- /* Create serial vector for solution */
+            withNVector_Serial c_dim sunctx 6896 $ \y -> do
+              -- /* Specify initial condition */
+              VS.imapM_ (\i v -> cNV_Ith_S y i v) c_init_cond
 
-  realtype T0 = RCONST(($vec-ptr:(double *c_sol_time))[0]); /* initial time              */
-  sunindextype c_dim = $(sunindextype c_dim);           /* number of dependent vars. */
+              let withArkStep
+                    | not implicit = \c_rhs -> withARKStepCreate c_rhs nullFunPtr
+                    | otherwise = \c_rhs -> withARKStepCreate nullFunPtr c_rhs
+              withArkStep c_rhs t0 y sunctx 8396 $ \cvode_mem -> do
+                -- /* Set the error handler */
+                cSUNContext_ClearErrHandlers sunctx >>= check 1093
+                cSUNContext_PushErrHandler sunctx c_report_error nullPtr >>= check 1093
 
-  /* t_start tracks the starting point of the integration in order to detect
-     empty integration interval and avoid a potential infinite loop;
-     see Note [CV_TOO_CLOSE]. Unlike T0, t_start is updated every time we
-     restart the solving after handling (or not) an event, or emitting
-     a requested time point.
-     Why not just look for the last recorded time in c_output_mat? Because
-     an event may have eventRecord = False and not be present there.
-  */
-  double t_start = T0;
+                when (c_fixedstep > 0.0) $ do
+                  cARKodeSetFixedStep cvode_mem c_fixedstep
 
-  int implicit = $(int c_method) >= ARKODE_MIN_DIRK_NUM;
+                -- /* Set the user data */
+                cARKodeSetUserData cvode_mem c_rhs_userdata >>= check 1949
 
-  /* Initialize data structures */
+                -- /* Create serial vector for absolute tolerances */
+                withNVector_Serial c_dim sunctx 6471 $ \tv -> do
+                  -- /* Specify tolerances */
+                  VS.imapM_ (\i v -> cNV_Ith_S tv i v) c_atol
 
-  void (*report_error)(int,const char*, const char*, char*, void*) = $fun:(void (*report_error)(int,const char*, const char*, char*, void*));
+                  cARKodeSetMinStep cvode_mem c_minstep >>= check 6433
+                  cARKodeSetMaxNumSteps cvode_mem c_max_n_steps >>= check 9904
+                  cARKodeSetMaxErrTestFails cvode_mem c_max_err_test_fails >>= check 2512
 
-  /* Initialize odeMaxEventsReached to False */
-  ($vec-ptr:(sunindextype *c_diagnostics))[10] = 0;
+                  -- /* Specify the scalar relative tolerance and vector absolute tolerances */
+                  cARKodeSVtolerances cvode_mem c_rtol tv >>= check 6212
 
-  y = N_VNew_Serial(c_dim, sunctx); /* Create serial vector for solution */
-  if (check_flag((void *)y, "N_VNew_Serial", 0, report_error)) return 6896;
-  /* Specify initial condition */
-  for (i = 0; i < c_dim; i++) {
-    NV_Ith_S(y,i) = ($vec-ptr:(double *c_init_cond))[i];
-  };
+                  -- /* Specify the root function */
+                  cARKodeRootInit cvode_mem c_n_event_specs c_event_fn >>= check 6290
+                  -- /* Disable the inactive roots warning; see https://git.novadiscovery.net/jinko/jinko/-/issues/2368 */
+                  cARKodeSetNoInactiveRootWarn cvode_mem >>= check 6291
 
-  ARKRhsFn c_rhs = $(int (*c_rhs)(double, N_Vector, N_Vector, UserData*));
-  if (!implicit) {
-    arkode_mem = ARKStepCreate(c_rhs, NULL, T0, y, sunctx);
-  } else {
-    arkode_mem = ARKStepCreate(NULL, c_rhs, T0, y, sunctx);
-  }
-  if (check_flag(arkode_mem, "ARKStepCreate", 0, report_error)) return 8396;
+                  -- /* Initialize a jacobian matrix and solver */
+                  let withLinearSolver f
+                        | implicit = do
+                            if (c_sparse_jac /= 0)
+                              then do
+                                withSUNSparseMatrix c_dim c_dim c_sparse_jac CSC_MAT sunctx 9061 $ \a -> do
+                                  withSUNLinSol_KLU y a sunctx 9316 $ \ls -> do
+                                    -- /* Attach matrix and linear solver */
+                                    cARKodeSetLinearSolver cvode_mem ls a >>= check 2625
+                                    f
+                              else do
+                                withSUNDenseMatrix c_dim c_dim sunctx 9316 $ \a -> do
+                                  withSUNLinSol_Dense y a sunctx 9316 $ \ls -> do
+                                    -- /* Attach matrix and linear solver */
+                                    cARKodeSetLinearSolver cvode_mem ls a >>= check 2625
+                                    f
+                        | otherwise = f
 
-  /* Set the error handler */
-  SUNContext_ClearErrHandlers(sunctx);
+                  withLinearSolver $ do
+                    -- /* Set the initial step size if there is one */
+                    when (c_init_step_size_set /= 0) $ do
+                      --   /* FIXME: We could check if the initial step size is 0 */
+                      --   /* or even NaN and then throw an error                 */
+                      cARKodeSetInitStep cvode_mem c_init_step_size >>= check 4010
 
-  SUNErrHandlerFn report_error_new_api = (SUNErrHandlerFn) $fun:(void (*report_error_new_api)(int,const char*, const char*, const char*, int, void*, void *));
-  flag = SUNContext_PushErrHandler(sunctx, report_error_new_api, NULL);
-  if (check_flag(&flag, "SUNContext_PushErrHandler", 1, report_error)) return 1093;
+                    -- /* Set the Jacobian if there is one */
+                    when (c_jac_set /= 0 && implicit) $ do
+                      cARKodeSetJacFn cvode_mem c_jac >>= check 3124
 
-  double c_fixedstep = $(double c_fixedstep);
-  if (c_fixedstep > 0.0) {
-    flag = ARKodeSetFixedStep(arkode_mem, c_fixedstep);
-    if (check_flag(&flag, "ARKodeSetFixedStep", 1, report_error)) return(1);
-  }
+                    -- /* Store initial conditions */
+                    VSM.write c_output_mat (0 * (fromIntegral c_dim + 1) + 0) (c_sol_time VS.! 0)
+                    let go j
+                          | j == c_dim = pure ()
+                          | otherwise = do
+                              VSM.write c_output_mat (0 * fromIntegral (c_dim + 1) + (fromIntegral j + 1)) =<< cNV_Ith_S' y (fromIntegral j)
+                              go (j + 1)
+                    go 0
 
-  /* Set the user data */
-  flag = ARKodeSetUserData(arkode_mem, $(UserData* c_rhs_userdata));
-  if (check_flag(&flag, "ARKodeSetUserData", 1, report_error)) return(1949);
+                    c_ontimepoint (fromIntegral init_loop.output_ind)
 
-  tv = N_VNew_Serial(c_dim, sunctx); /* Create serial vector for absolute tolerances */
-  if (check_flag((void *)tv, "N_VNew_Serial", 0, report_error)) return 6471;
-  /* Specify tolerances */
-  for (i = 0; i < c_dim; i++) {
-    NV_Ith_S(tv,i) = ($vec-ptr:(double *c_atol))[i];
-  };
+                    if implicit
+                      then do
+                        cARKStepSetTableNum cvode_mem c_method (-1) >>= check 26643
+                      else do
+                        cARKStepSetTableNum cvode_mem (-1) c_method >>= check 26643
 
-  flag = ARKodeSetMinStep(arkode_mem, $(double c_minstep));
-  if (check_flag(&flag, "ARKodeSetMinStep", 1, report_error)) return 6433;
-  flag = ARKodeSetMaxNumSteps(arkode_mem, $(sunindextype c_max_n_steps));
-  if (check_flag(&flag, "ARKodeSetMaxNumSteps", 1, report_error)) return 9904;
-  flag = ARKodeSetMaxErrTestFails(arkode_mem, $(int c_max_err_test_fails));
-  if (check_flag(&flag, "ARKodeSetMaxErrTestFails", 1, report_error)) return 2512;
+                    let loop :: StateT LoopState IO ()
+                        loop = do
+                          s <- get
+                          let ti = fromMaybe (error "Incorrect c_sol_time access") $ c_sol_time VS.!? s.input_ind
 
-  /* Specify the scalar relative tolerance and vector absolute tolerances */
-  flag = ARKodeSVtolerances(arkode_mem, $(double c_rtol), tv);
-  if (check_flag(&flag, "ARKodeSVtolerances", 1, report_error)) return(6212);
+                          next_time_event <- liftIO c_next_time_event
 
-  /* Specify the root function */
-  flag = ARKodeRootInit(arkode_mem, $(int c_n_event_specs), $(int (* c_event_fn) (realtype, N_Vector, realtype*, UserData*)));
-  if (check_flag(&flag, "ARKodeRootInit", 1, report_error)) return(6290);
-  /* Disable the inactive roots warning; see https://git.novadiscovery.net/jinko/jinko/-/issues/2368 */
-  flag = ARKodeSetNoInactiveRootWarn(arkode_mem);
-  if (check_flag(&flag, "ARKodeSetNoInactiveRootWarn", 1, report_error)) return(6291);
+                          --   // Haskell failure in the next time event function
+                          when (next_time_event == -1) $ do
+                            s <- get
+                            liftIO $ throwIO $ Break s
 
-  if (implicit) {
-    /* Initialize a jacobian matrix and solver */
-    int c_sparse_jac = $(int c_sparse_jac);
-    if (c_sparse_jac) {
-      A = SUNSparseMatrix(c_dim, c_dim, c_sparse_jac, CSC_MAT, sunctx);
-      if (check_flag((void *)A, "SUNSparseMatrix", 0, report_error)) return 9061;
-      LS = SUNLinSol_KLU(y, A, sunctx);
-      if (check_flag((void *)LS, "SUNLinSol_KLU", 0, report_error)) return 9316;
-    } else {
-      A = SUNDenseMatrix(c_dim, c_dim, sunctx);
-      if (check_flag((void *)A, "SUNDenseMatrix", 0, report_error)) return 9061;
-      LS = SUNLinSol_Dense(y, A, sunctx);
-      if (check_flag((void *)LS, "SUNLinSol_Dense", 0, report_error)) return 9316;
-    }
+                          when (next_time_event < s.t_start) $ do
+                            s <- get
+                            debug $ printf "time-based event is in the past: next event time = %.4f while we are at %.4f" (coerce next_time_event :: Double) (coerce s.t_start :: Double)
+                            liftIO $ throwIO $ Finish s
 
-      /* Attach matrix and linear solver */
-      flag = ARKodeSetLinearSolver(arkode_mem, LS, A);
-      if (check_flag(&flag, "ARKodeSetLinearSolver", 1, report_error)) return 2625;
-  }
+                          let next_stop_time = min ti next_time_event
+                          debug $ printf "Main loop iteration: t = %.17g (%a), next time point (ti) = %.17g, next time event = %.17g" (coerce s.t_start :: Double) (coerce ti :: Double) (coerce next_time_event :: Double)
+                          (t, flag) <- liftIO $ alloca $ \t_ptr -> do
+                            flag <- cARKodeEvolve cvode_mem next_stop_time y t_ptr ARK_NORMAL
+                            t <- peek t_ptr
+                            pure (t, flag)
 
-  /* Set the initial step size if there is one */
-  if ($(int c_init_step_size_set)) {
-    /* FIXME: We could check if the initial step size is 0 */
-    /* or even NaN and then throw an error                 */
-    flag = ARKodeSetInitStep(arkode_mem, $(double c_init_step_size));
-    if (check_flag(&flag, "ARKodeSetInitStep", 1, report_error)) return 4010;
-  }
+                          debug $ printf "ARKode returned %d; now t = %.17g\n" (fromIntegral flag :: Int) (coerce t :: Double)
+                          let root_based_event = flag == ARK_ROOT_RETURN
+                          let time_based_event = t == next_time_event
+                          (t, _flag) <-
+                            if flag == ARK_TOO_CLOSE && not time_based_event
+                              then do
+                                --     /* See Note [CV_TOO_CLOSE]
+                                --        No solving was required; just set the time t manually and continue
+                                --        as if solving succeeded. */
+                                debug $ printf "Got ARK_TOO_CLOSE; no solving was required; proceeding to t = %.17g" (coerce next_stop_time :: Double)
+                                pure (next_stop_time, flag)
+                              else do
+                                s <- get
+                                if t == next_stop_time && t == s.t_start && flag == ARK_ROOT_RETURN && not time_based_event
+                                  then do
+                                    --     /* See Note [CV_TOO_CLOSE]
+                                    --        Probably the initial step size was set, and that's why we didn't
+                                    --        get CV_TOO_CLOSE.
+                                    --        Pretend that the root didn't happen, lest we keep handling it
+                                    --        forever. */
+                                    debug $ ("Got a root but t == t_start == next_stop_time; pretending it didn't happen" :: String)
+                                    pure (t, ARK_SUCCESS)
+                                  else do
+                                    if not (flag == ARK_TOO_CLOSE && time_based_event) && flag < 0
+                                      then do
+                                        liftIO $ withNVector_Serial c_dim sunctx 12341234 $ \ele -> do
+                                          liftIO $ withNVector_Serial c_dim sunctx 12341234 $ \weights -> do
+                                            flag <- liftIO $ cARKodeGetEstLocalErrors cvode_mem ele
+                                            flag' <- liftIO $ cARKodeGetErrWeights cvode_mem weights
+                                            when (flag == ARK_SUCCESS && flag' == ARK_SUCCESS) $ do
+                                              let go ix destination source
+                                                    | ix == c_dim = pure ()
+                                                    | otherwise = do
+                                                        v <- peekElemOff source (fromIntegral ix)
+                                                        VSM.write destination (fromIntegral ix) v
+                                                        go (ix + 1) destination source
+                                              go 0 c_local_error =<< cN_VGetArrayPointer ele
+                                              go 0 c_var_weight =<< cN_VGetArrayPointer weights
 
-  /* Set the Jacobian if there is one */
-  if ($(int c_jac_set) && implicit) {
-    ARKLsJacFn c_jac = $(int (*c_jac)(realtype, N_Vector, N_Vector, SUNMatrix, UserData*, N_Vector, N_Vector, N_Vector));
-    flag = ARKodeSetJacFn(arkode_mem, c_jac);
-    if (check_flag(&flag, "ARKodeSetJacFn", 1, report_error)) return 3124;
-  }
+                                              VSM.write c_local_error_set 0 1
+                                            liftIO $ throwIO (ReturnCode 45)
+                                      else pure (t, flag)
 
-  /* Store initial conditions */
-  ($vec-ptr:(double *c_output_mat))[0 * (c_dim + 1) + 0] = ($vec-ptr:(double *c_sol_time))[0];
-  for (j = 0; j < c_dim; j++) {
-    ($vec-ptr:(double *c_output_mat))[0 * (c_dim + 1) + (j + 1)] = NV_Ith_S(y,j);
-  }
-  $fun:(void (*c_ontimepoint)(int))(output_ind);
+                          --   /* Store the results for Haskell */
+                          s <- get
+                          VSM.write c_output_mat (s.output_ind * (fromIntegral c_dim + 1) + 0) t
+                          let go j
+                                | j == c_dim = pure ()
+                                | otherwise = do
+                                    liftIO $ VSM.write c_output_mat (s.output_ind * fromIntegral (c_dim + 1) + (fromIntegral j + 1)) =<< cNV_Ith_S' y (fromIntegral j)
+                                    go (j + 1)
+                          go 0
 
-  /* Set the Runge-Kutta method */
-  if (implicit) {
-    flag = ARKStepSetTableNum(arkode_mem, $(int c_method), -1);
-  } else {
-    flag = ARKStepSetTableNum(arkode_mem, -1, $(int c_method));
-  }
-  if (check_flag(&flag, "ARKStepSetTableNum", 1, report_error)) return 26643;
+                          s <- get
+                          liftIO $ c_ontimepoint (fromIntegral s.output_ind)
+                          modify $ \s -> s {output_ind = s.output_ind + 1}
 
-  while (1) {
-     // The solver will run until it terminates or receive a signal to stop by the
-     // way of a non null value in *ptrSTop
-     // The signal is an exception from outside (see the solve function in
-     // Numeric/Sundials.hs
-    // Ensure proper memory barrier.
-    // This cannot be simply replaced by if(*ptrStop) because the compiler is free to consider ptrStop as a constant for the complete loop execution.
-    // So instead, we use __atomic_load to force the load
-    int stopFlag = 0;
-    __atomic_load($(int* ptrStop), &stopFlag, __ATOMIC_SEQ_CST);
+                          s <- get
+                          VSM.write c_n_rows 0 (fromIntegral s.output_ind)
 
-    if(stopFlag)
-    {
-      break;
-    }
+                          when (root_based_event || time_based_event) $ do
+                            debug ("Got an event")
+                            when (fromIntegral s.event_ind >= c_max_events) $ do
+                              debug ("Maximum number of events reached")
+                              --       /* We reached the maximum number of events.
+                              --          Either the maximum number of events is set to 0,
+                              --          or there's a bug in our code below. In any case return an error.
+                              --       */
+                              liftIO $ throwIO (ReturnCode 8630)
 
-    double ti = ($vec-ptr:(double *c_sol_time))[input_ind];
-    double next_time_event = ($fun:(double (*c_next_time_event)()))();
+                            --     /* How many events triggered? */
+                            n_events_triggered <-
+                              if not root_based_event
+                                then pure 0
+                                else do
+                                  debug ("Handling root-based events")
+                                  liftIO $ VSM.unsafeWith c_root_info $ \c_root_info_ptr -> do
+                                    flag <- cARKodeGetRootInfo cvode_mem c_root_info_ptr
+                                    when (flag < 0) $ do
+                                      throwIO $ ReturnCode 2829
+                                    let go i n_events_triggered
+                                          | i >= c_n_event_specs = pure n_events_triggered
+                                          | otherwise = do
+                                              ev <- VSM.read c_root_info (fromIntegral i)
+                                              let req_dir = c_requested_event_direction VS.! (fromIntegral i)
 
-    // Haskell failure in the next time event function
-    if(next_time_event == -1)
-      break;
-    if (next_time_event < t_start) {
-      size_t msg_size = 1000;
-      char *msg = alloca(msg_size);
-      snprintf(msg, msg_size, "time-based event is in the past: next event time = %.4f while we are at %.4f", next_time_event, t_start);
-      report_error(0, "hmatrix-sundials", "solveC", msg, NULL);
-      retval = 5669;
-      goto finish;
-    }
-    double next_stop_time = fmin(ti, next_time_event);
-    flag = ARKodeEvolve(arkode_mem, next_stop_time, y, &t, ARK_NORMAL); /* call integrator */
-    int root_based_event = flag == ARK_ROOT_RETURN;
-    int time_based_event = t == next_time_event;
-    if (flag == ARK_TOO_CLOSE) {
-      /* See Note [CV_TOO_CLOSE]
-         No solving was required; just set the time t manually and continue
-         as if solving succeeded. */
-      t = next_stop_time;
-    }
-    else
-    if (t == next_stop_time && t == t_start && flag == ARK_ROOT_RETURN && !time_based_event) {
-      /* See Note [CV_TOO_CLOSE]
-         Probably the initial step size was set, and that's why we didn't
-         get ARK_TOO_CLOSE.
-         Pretend that the root didn't happen, lest we keep handling it
-         forever. */
-      flag = ARK_SUCCESS;
-    }
-    else
-    if (!(flag == ARK_TOO_CLOSE && time_based_event) &&
-      check_flag(&flag, "ARKodeEvolve", 1, report_error)) {
+                                              if ev /= 0 && ev * req_dir >= 0
+                                                then do
+                                                  --           /* After the above call to ARKodeGetRootInfo, c_root_info has an
+                                                  --           entry per EventSpec. Here we reuse the same array but convert it
+                                                  --           into one that contains indices of triggered events. */
+                                                  --           c_root_info[n_events_triggered++] = i;
+                                                  VSM.write c_root_info n_events_triggered i
+                                                  go (i + 1) (n_events_triggered + 1)
+                                                else do
+                                                  go (i + 1) n_events_triggered
+                                    go 0 0
 
-      N_Vector ele = N_VNew_Serial(c_dim, sunctx);
-      N_Vector weights = N_VNew_Serial(c_dim, sunctx);
-      flag = ARKodeGetEstLocalErrors(arkode_mem, ele);
-      // ARK_SUCCESS is defined is 0, so we OR the flags
-      flag = flag || ARKodeGetErrWeights(arkode_mem, weights);
-      if (flag == ARK_SUCCESS) {
-        double *arr_ptr = N_VGetArrayPointer(ele);
-        memcpy(($vec-ptr:(double *c_local_error)), arr_ptr, c_dim * sizeof(double));
+                            (record_events, stop_solver) <-
+                              if (n_events_triggered > 0 || time_based_event)
+                                then do
+                                  debug $ printf "Calling the event handler; n_events_triggered = %d; time_based_event = %d" n_events_triggered (bool (0 :: Int) 1 time_based_event)
+                                  (stop_solver, record_events, err) <- liftIO $ alloca $ \stop_solver_ptr -> alloca $ \record_event_ptr -> do
+                                    --       /* Update the state with the supplied function */
+                                    err <- VSM.unsafeWith c_root_info $ \c_root_info_ptr -> do
+                                      err <- c_apply_event (fromIntegral n_events_triggered) c_root_info_ptr t (coerce y) (coerce y) stop_solver_ptr record_event_ptr
+                                      pure err
+                                    stop_solver <- peek stop_solver_ptr
+                                    record_event <- peek record_event_ptr
+                                    pure (stop_solver, record_event, err)
 
-        arr_ptr = N_VGetArrayPointer(weights);
-        memcpy(($vec-ptr:(double *c_var_weight)), arr_ptr, c_dim * sizeof(double));
+                                  --       // If the event handled failed internally, we stop the solving
+                                  when (err /= 0) $ do
+                                    s <- get
+                                    liftIO $ throwIO $ Break s
 
-        ($vec-ptr:(int *c_local_error_set))[0] = 1;
-      }
-      N_VDestroy(ele);
-      N_VDestroy(weights);
-      return 45;
-    }
+                                  pure (record_events, stop_solver)
+                                else pure (0, 0)
 
-    /* Store the results for Haskell */
-    ($vec-ptr:(double *c_output_mat))[output_ind * (c_dim + 1) + 0] = t;
-    for (j = 0; j < c_dim; j++) {
-      ($vec-ptr:(double *c_output_mat))[output_ind * (c_dim + 1) + (j + 1)] = NV_Ith_S(y,j);
-    }
+                            if record_events /= 0
+                              then do
+                                debug ("Recording events")
+                                --       /* A corner case: if the time-based event triggers at the very beginning,
+                                --          then we don't want to duplicate the initial row, so rewind it back.
+                                --          Note that we do this only in the branch where record_events is true;
+                                --          otherwise we may end up erasing the initial row (see below). */
+                                s <- get
+                                when (t == c_sol_time VS.! 0 && s.output_ind == 2) $ do
+                                  --         /* c_n_rows will be updated below anyway */
+                                  modify $ \s -> s {output_ind = s.output_ind - 1}
 
-    $fun:(void (*c_ontimepoint)(int))(output_ind);
+                                s <- get
+                                VSM.write c_output_mat (s.output_ind * (fromIntegral c_dim + 1) + 0) t
+                                let go j
+                                      | j == c_dim = pure ()
+                                      | otherwise = do
+                                          liftIO $ VSM.write c_output_mat (s.output_ind * fromIntegral (c_dim + 1) + (fromIntegral j + 1)) =<< cNV_Ith_S' y (fromIntegral j)
+                                          go (j + 1)
+                                go 0
 
-    output_ind++;
-    ($vec-ptr:(int *c_n_rows))[0] = output_ind;
+                                s <- get
+                                liftIO $ c_ontimepoint $ fromIntegral s.output_ind
+                                modify $ \s -> s {event_ind = s.event_ind + 1, output_ind = s.output_ind + 1}
+                                s <- get
+                                VSM.write c_n_rows 0 (fromIntegral s.output_ind)
+                              else do
+                                --       /* Remove the saved row — unless the event time also coincides with a requested time point */
+                                when (t /= ti) $ do
+                                  modify $ \s -> s {output_ind = s.output_ind - 1}
+                                  s <- get
+                                  VSM.write c_n_rows 0 (fromIntegral s.output_ind)
+                            s <- get
+                            stop_solver <-
+                              if (fromIntegral s.event_ind >= c_max_events)
+                                then do
+                                  debug ("Reached max_events; returning")
+                                  VSM.write c_diagnostics 10 1
+                                  pure 1
+                                else pure stop_solver
+                            when (stop_solver /= 0) $ do
+                              debug ("Stopping the hmatrix-sundials solver as requested")
+                              s <- get
+                              liftIO $ throwIO $ Finish s
 
-    if (root_based_event || time_based_event) {
-      if (event_ind >= $(int c_max_events)) {
-        /* We reached the maximum number of events.
-           Either the maximum number of events is set to 0,
-           or there's a bug in our code below. In any case return an error.
-        */
-        return 8630;
-      }
+                            when (n_events_triggered > 0 || time_based_event) $ do
+                              debug ("Re-initializing the system")
+                              if not implicit
+                                then do
+                                  liftIO $ cARKStepReInit cvode_mem c_rhs nullFunPtr t y >>= check 1576
+                                else do
+                                  liftIO $ cARKStepReInit cvode_mem nullFunPtr c_rhs t y >>= check 1576
 
-      /* How many events triggered? */
-      int n_events_triggered = 0;
-      int *c_root_info = ($vec-ptr:(int *c_root_info));
-      if (root_based_event) {
-        flag = ARKodeGetRootInfo(arkode_mem, c_root_info);
-        if (check_flag(&flag, "ARKodeGetRootInfo", 1, report_error)) return 2829;
-        for (i = 0; i < $(int c_n_event_specs); i++) {
-          int ev = c_root_info[i];
-          int req_dir = ($vec-ptr:(const int *c_requested_event_direction))[i];
-          if (ev != 0 && ev * req_dir >= 0) {
-            /* After the above call to CVodeGetRootInfo, c_root_info has an
-            entry per EventSpec. Here we reuse the same array but convert it
-            into one that contains indices of triggered events. */
-            c_root_info[n_events_triggered++] = i;
-          }
-        }
-      }
+                          when (t == ti) $ do
+                            modify $ \s -> s {input_ind = s.input_ind + 1}
+                            s <- get
+                            when (s.input_ind >= fromIntegral c_n_sol_times) $ do
+                              s <- get
+                              liftIO $ throwIO $ Finish s
 
-      /* Should we stop the solver? */
-      int stop_solver = 0;
-      /* Should we record the state before/after the event in the output matrix? */
-      int record_events = 0;
-      if (n_events_triggered > 0 || time_based_event) {
-        /* Update the state with the supplied function */
-        int error = $fun:(int (* c_apply_event) (int, int*, double, N_Vector y, N_Vector z, int*, int*))(n_events_triggered, c_root_info, t, y, y, &stop_solver, &record_events);
+                          modify $ \s -> s {t_start = t}
+                          loop
+                    resM <- try $ execStateT loop init_loop
+                    case resM of
+                      Left (ReturnCode c)
+                        | c == fromIntegral ARK_SUCCESS -> pure ARK_SUCCESS
+                        | otherwise -> pure $ (fromIntegral c)
+                      Left (ReturnCodeWithMessage _message c)
+                        | c == fromIntegral ARK_SUCCESS -> pure ARK_SUCCESS
+                        | otherwise -> pure $ (fromIntegral c)
+                      Right finalState -> end cvode_mem finalState
+                      Left (Break finalState) -> end cvode_mem finalState
+                      Left (Finish finalState) -> end cvode_mem finalState
+  where
+    end cvode_mem finalState = do
+      -- /* The number of actual roots we found */
+      VSM.write c_n_events 0 (fromIntegral finalState.event_ind)
 
-        // If the event handled failed internally, we stop the solving
-        if(error)
-          break;
-      }
+      -- /* Get some final statistics on how the solve progressed */
+      nst <- cvGet cARKodeGetNumSteps cvode_mem
+      VSM.write c_diagnostics 0 (fromIntegral nst)
 
-      if (record_events) {
-        /* A corner case: if the time-based event triggers at the very beginning,
-           then we don't want to duplicate the initial row, so rewind it back.
-           Note that we do this only in the branch where record_events is true;
-           otherwise we may end up erasing the initial row (see below). */
-        if (t == ($vec-ptr:(double *c_sol_time))[0] && output_ind == 2) {
-          output_ind--;
-          /* c_n_rows will be updated below anyway */
-        }
+      nst_a <- cvGet cARKodeGetNumStepAttempts cvode_mem
+      VSM.write c_diagnostics 1 (fromIntegral nst_a)
 
-        ($vec-ptr:(double *c_output_mat))[output_ind * (c_dim + 1) + 0] = t;
-        for (j = 0; j < c_dim; j++) {
-          ($vec-ptr:(double *c_output_mat))[output_ind * (c_dim + 1) + (j + 1)] = NV_Ith_S(y,j);
-        }
-        $fun:(void (*c_ontimepoint)(int))(output_ind);
+      (nfe, nfi) <- alloca $ \nfe -> do
+        alloca $ \nfi -> do
+          errCode <- cARKStepGetNumRhsEvals cvode_mem nfe nfi
+          when (errCode /= ARK_SUCCESS) $ do
+            error $ "Failure during nfe/nfi get"
 
-        event_ind++;
-        output_ind++;
-        ($vec-ptr:(int *c_n_rows))[0] = output_ind;
-      } else {
-        /* Remove the saved row — unless the event time also coincides with a requested time point */
-        if (t != ti) {
-          output_ind--;
-          ($vec-ptr:(int *c_n_rows))[0] = output_ind;
-        }
-      }
-      if (event_ind >= $(int c_max_events)) {
-        ($vec-ptr:(sunindextype *c_diagnostics))[10] = 1;
-        stop_solver = 1;
-      }
-      if (stop_solver) {
-        goto finish;
-      }
+          (,) <$> peek nfe <*> peek nfi
 
-      if (n_events_triggered > 0 || time_based_event) {
-        /* Reinitialize */
-        if (!implicit) {
-          flag = ARKStepReInit(arkode_mem, c_rhs, NULL, t, y);
-        } else {
-          flag = ARKStepReInit(arkode_mem, NULL, c_rhs, t, y);
-        }
-        if (check_flag(&flag, "ARKStepReInit", 1, report_error)) return(1576);
-      }
-    }
-    if (t == ti) {
-      if (++input_ind >= $(int c_n_sol_times))
-        goto finish;
-    }
-    t_start = t;
-  }
+      VSM.write c_diagnostics 2 (fromIntegral nfe)
+      VSM.write c_diagnostics 3 (fromIntegral nfi)
 
-  finish:
+      nsetups <- cvGet cARKodeGetNumLinSolvSetups cvode_mem
+      VSM.write c_diagnostics 4 (fromIntegral nsetups)
 
-  /* The number of actual roots we found */
-  ($vec-ptr:(int *c_n_events))[0] = event_ind;
+      netf <- cvGet cARKodeGetNumErrTestFails cvode_mem
+      VSM.write c_diagnostics 5 (fromIntegral netf)
 
-  /* Get some final statistics on how the solve progressed */
-  flag = ARKodeGetNumSteps(arkode_mem, &nst);
-  check_flag(&flag, "ARKodeGetNumSteps", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[0] = nst;
+      nni <- cvGet cARKodeGetNumNonlinSolvIters cvode_mem
+      VSM.write c_diagnostics 6 (fromIntegral nni)
 
-  flag = ARKodeGetNumStepAttempts(arkode_mem, &nst_a);
-  check_flag(&flag, "ARKodeGetNumStepAttempts", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[1] = nst_a;
+      let implicit = c_method >= ARKODE_MIN_DIRK_NUM
+      if implicit
+        then do
+          ncfn <- cvGet cARKodeGetNumNonlinSolvConvFails cvode_mem
+          VSM.write c_diagnostics 7 (fromIntegral ncfn)
 
-  flag = ARKStepGetNumRhsEvals(arkode_mem, &nfe, &nfi);
-  check_flag(&flag, "ARKStepGetNumRhsEvals", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[2] = nfe;
-  ($vec-ptr:(sunindextype *c_diagnostics))[3] = nfi;
+          nje <- cvGet cARKodeGetNumJacEvals cvode_mem
+          VSM.write c_diagnostics 8 (fromIntegral nje)
 
-  flag = ARKodeGetNumLinSolvSetups(arkode_mem, &nsetups);
-  check_flag(&flag, "ARKodeGetNumLinSolvSetups", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[4] = nsetups;
+          nfeLS <- cvGet cARKodeGetNumLinRhsEvals cvode_mem
+          VSM.write c_diagnostics 9 (fromIntegral nfeLS)
+        else do
+          VSM.write c_diagnostics 7 0
+          VSM.write c_diagnostics 8 0
+          VSM.write c_diagnostics 9 0
 
-  flag = ARKodeGetNumErrTestFails(arkode_mem, &netf);
-  check_flag(&flag, "ARKodeGetNumErrTestFails", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[5] = netf;
+      pure ARK_SUCCESS
 
-  flag = ARKodeGetNumNonlinSolvIters(arkode_mem, &nni);
-  check_flag(&flag, "ARKodeGetNumNonlinSolvIters", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[6] = nni;
+foreign import ccall "SUNContext_PushErrHandler" cSUNContext_PushErrHandler :: SUNContext -> FunPtr ReportErrorFnNew -> Ptr () -> IO CInt
 
-  if (implicit) {
-    flag = ARKodeGetNumNonlinSolvConvFails(arkode_mem, &ncfn);
-    check_flag(&flag, "ARKodeGetNumNonlinSolvConvFails", 1, report_error);
-    ($vec-ptr:(sunindextype *c_diagnostics))[7] = ncfn;
+--  |]
 
-    flag = ARKodeGetNumJacEvals(arkode_mem, &nje);
-    check_flag(&flag, "ARKodeGetNumJacEvals", 1, report_error);
-    ($vec-ptr:(sunindextype *c_diagnostics))[8] = ncfn;
+{- Note [CV_TOO_CLOSE]
+   ~~~~~~~~~~~~~~~~~~~
+   One edge condition that may occur is that an event time may exactly
+   coincide with a solving time (e.g. they are both exactly equal to an
+   integer). Then the following will happen:
 
-    flag = ARKodeGetNumLinRhsEvals(arkode_mem, &nfeLS);
-    check_flag(&flag, "ARKodeGetNumRhsEvals", 1, report_error);
-    ($vec-ptr:(sunindextype *c_diagnostics))[9] = ncfn;
-  } else {
-    ($vec-ptr:(sunindextype *c_diagnostics))[7] = 0;
-    ($vec-ptr:(sunindextype *c_diagnostics))[8] = 0;
-    ($vec-ptr:(sunindextype *c_diagnostics))[9] = 0;
-  }
+   * Sundials will indicate a root at t1.
+   * We will handle the event and re-initialize the system at t1.
+   * We restart Sundials with the tout being equal to the next solving time,
+     which also happens to be equal t1.
+   * Sundials sees that the start and end solving times are equal, and
+     returns the CV_TOO_CLOSE error.
 
-  /* Clean up and return */
-  N_VDestroy(y);            /* Free y vector          */
-  N_VDestroy(tv);           /* Free tv vector         */
-  ARKodeFree(&arkode_mem);  /* Free integrator memory */
-  SUNLinSolFree(LS);        /* Free linear solver     */
-  SUNMatDestroy(A);         /* Free A matrix          */
-  SUNContext_Free(&sunctx);
+   Calculating on our side when the start and end times are "too close" by
+   Sundials standards is a bit complicated (see the code at the beginning
+   of the cvHin function). It's much easier just to call Sundials and
+   handle the error.
 
-  return ARK_SUCCESS;
- } |]
+   For that, however, we need to make sure we ignore CV_TOO_CLOSE in our
+   error handler so as not to confuse the end users with mysterious error
+   messages in the logs.
+
+   That said, we can't always rely on CV_TOO_CLOSE. When the initial step
+   size is set, cvHin is not called, and CV_TOO_CLOSE is not triggered.
+   Therefore we also add an explicit check to avoid an infinite loop of
+   integrating over an empty interval.
+
+   One exception to all of the above is a time-based event that may be
+   scheduled for an exact same time as a time grid. In that case, we still
+   handle it. We don't fall into an infinite loop because once we handle
+   a time-based event, the next time-based event should be at a strictly
+   later time.
+-}
+
+
+{- NOTE [SAFETY]
+   ~~~~~~~~~~~~~~~~~~~
+
+All the call are marked (implicitly) as "safe" because they can, in theory, all call the log callback and hence "unsafe" is not relevant.
+
+-}
+
+-- An opaque pointer to a SUNContext
+newtype SUNContext = SUNContext (Ptr Void)
+  deriving newtype (Storable)
+
+foreign import ccall "SUNGetErrMsg" cSUNGetErrMsg :: CInt -> IO CString
+
+withSUNContext :: (HasCallStack) => (SUNContext -> IO a) -> IO a
+withSUNContext cont = do
+  alloca $ \ptr -> do
+    let create = do
+          errCode <- cSUNContext_Create 0 ptr
+          when (errCode /= 0) $ do
+            errMsg <- cSUNGetErrMsg errCode
+            msg <- peekCString errMsg
+            error msg
+          pure ()
+        destroy = cSUNContext_Free ptr
+    bracket_ create destroy $ do
+      sunctx <- peek ptr
+      cont sunctx
+
+check :: (HasCallStack) => Int -> CInt -> IO ()
+check retCode status
+  | status == ARK_SUCCESS = pure ()
+  | otherwise = throwIO (ReturnCode retCode)
+
+foreign import ccall "SUNContext_Create" cSUNContext_Create :: Int -> Ptr SUNContext -> IO CInt
+
+foreign import ccall "SUNContext_Free" cSUNContext_Free :: Ptr SUNContext -> IO CInt
+
+-- | An opaque pointer to a ARKodeMem
+newtype ARKodeMem = ARKodeMem (Ptr Void)
+  deriving newtype (Storable)
+
+withARKStepCreate ::
+  (HasCallStack) =>
+  ( FunPtr OdeRhsCType ->
+    FunPtr OdeRhsCType ->
+    CDouble ->
+    N_Vector ->
+    SUNContext ->
+    Int ->
+    (ARKodeMem -> IO c) ->
+    IO c
+  )
+withARKStepCreate explicit implicit t0 y0 sunctx errCode f = do
+  let create = do
+        res@(ARKodeMem ptr) <- cARKStepCreate explicit implicit t0 y0 sunctx
+        if ptr == nullPtr
+          then throwIO $ ReturnCodeWithMessage "Error in cvodeCreate" errCode
+          else pure res
+      destroy p = do
+        with p cARKStepFree
+  bracket create destroy f
+
+foreign import ccall "ARKStepCreate" cARKStepCreate :: FunPtr OdeRhsCType -> FunPtr OdeRhsCType -> CDouble -> N_Vector -> SUNContext -> IO ARKodeMem
+
+foreign import ccall "ARKStepFree" cARKStepFree :: Ptr ARKodeMem -> IO ()
+
+-- | An opaque pointer to an N_Vector
+newtype N_Vector = N_Vector (Ptr Void)
+
+foreign import ccall "N_VNew_Serial" unsafeN_VNew_Serial :: SunIndexType -> SUNContext -> IO N_Vector
+
+foreign import ccall "N_VDestroy" unsafeN_VDestroy :: N_Vector -> IO ()
+
+withNVector_Serial :: SunIndexType -> SUNContext -> Int -> (N_Vector -> IO a) -> IO a
+withNVector_Serial t suncontext errCode f = do
+  let create = do
+        res@(N_Vector ptr) <- unsafeN_VNew_Serial t suncontext
+        when (ptr == nullPtr) $ do
+          throwIO $ ReturnCodeWithMessage "Failure in N_VNew_Serial" errCode
+        pure res
+  bracket create unsafeN_VDestroy f
+
+cNV_Ith_S :: N_Vector -> Int -> CDouble -> IO ()
+cNV_Ith_S (N_Vector ptr) i v = do
+  qtr <- getContentPtr ptr
+  rtr <- getData qtr
+  pokeElemOff rtr i v
+
+cNV_Ith_S' :: N_Vector -> Int -> IO CDouble
+cNV_Ith_S' (N_Vector ptr) i = do
+  qtr <- getContentPtr ptr
+  rtr <- getData qtr
+  peekElemOff rtr i
+
+foreign import ccall "ARKodeSetUserData" cARKodeSetUserData :: ARKodeMem -> Ptr UserData -> IO CInt
+
+foreign import ccall "ARKodeSetMinStep" cARKodeSetMinStep :: ARKodeMem -> CDouble -> IO CInt
+
+foreign import ccall "ARKodeSetMaxNumSteps" cARKodeSetMaxNumSteps :: ARKodeMem -> SunIndexType -> IO CInt
+
+foreign import ccall "ARKodeSetMaxErrTestFails" cARKodeSetMaxErrTestFails :: ARKodeMem -> CInt -> IO CInt
+
+foreign import ccall "ARKodeSVtolerances" cARKodeSVtolerances :: ARKodeMem -> CDouble -> N_Vector -> IO CInt
+
+foreign import ccall "ARKodeRootInit" cARKodeRootInit :: ARKodeMem -> CInt -> FunPtr EventConditionCType -> IO CInt
+
+foreign import ccall "ARKodeSetNoInactiveRootWarn" cARKodeSetNoInactiveRootWarn :: ARKodeMem -> IO CInt
+
+foreign import ccall "ARKodeSetLinearSolver" cARKodeSetLinearSolver :: ARKodeMem -> SUNLinearSolver -> SUNMatrix -> IO CInt
+
+foreign import ccall "ARKodeSetInitStep" cARKodeSetInitStep :: ARKodeMem -> CDouble -> IO CInt
+
+foreign import ccall "SUNSparseMatrix" cSUNSparseMatrix :: SunIndexType -> SunIndexType -> CInt -> CInt -> SUNContext -> IO SUNMatrix
+
+foreign import ccall "SUNLinSol_KLU" cSUNLinSol_KLU :: N_Vector -> SUNMatrix -> SUNContext -> IO SUNLinearSolver
+
+foreign import ccall "SUNDenseMatrix" cSUNDenseMatrix :: SunIndexType -> SunIndexType -> SUNContext -> IO SUNMatrix
+
+foreign import ccall "SUNLinSol_Dense" cSUNLinSol_Dense :: N_Vector -> SUNMatrix -> SUNContext -> IO SUNLinearSolver
+
+foreign import ccall "SUNMatDestroy" cSUNMatDestroy :: SUNMatrix -> IO ()
+
+foreign import ccall "SUNLinSolFree" cSUNLinSolFree :: SUNLinearSolver -> IO CInt
+
+withSUNDenseMatrix :: (HasCallStack) => SunIndexType -> SunIndexType -> SUNContext -> CInt -> (SUNMatrix -> IO a) -> IO a
+withSUNDenseMatrix dim dim' sunctx errCode f = do
+  let create = do
+        mat@(SUNMatrix ptr) <- cSUNDenseMatrix dim dim' sunctx
+
+        when (ptr == nullPtr) $ do
+          throwIO $ ReturnCode $ fromIntegral errCode
+
+        pure mat
+  bracket create cSUNMatDestroy f
+
+-- SUNLinSolFree ls
+
+withSUNSparseMatrix :: (HasCallStack) => SunIndexType -> SunIndexType -> CInt -> CInt -> SUNContext -> CInt -> (SUNMatrix -> IO a) -> IO a
+withSUNSparseMatrix dim dim' jac set sunctx errCode f = do
+  let create = do
+        mat@(SUNMatrix ptr) <- cSUNSparseMatrix dim dim' jac set sunctx
+
+        when (ptr == nullPtr) $ do
+          throwIO $ ReturnCode $ fromIntegral errCode
+
+        pure mat
+  bracket create cSUNMatDestroy f
+
+withSUNLinSol_Dense :: (HasCallStack) => N_Vector -> SUNMatrix -> SUNContext -> CInt -> (SUNLinearSolver -> IO a) -> IO a
+withSUNLinSol_Dense vec mat sunctx errCode f = do
+  let create = do
+        ls@(SUNLinearSolver ptr) <- cSUNLinSol_Dense vec mat sunctx
+
+        when (ptr == nullPtr) $ do
+          throwIO $ ReturnCode $ fromIntegral errCode
+
+        pure ls
+  bracket create cSUNLinSolFree f
+
+withSUNLinSol_KLU :: (HasCallStack) => N_Vector -> SUNMatrix -> SUNContext -> CInt -> (SUNLinearSolver -> IO a) -> IO a
+withSUNLinSol_KLU vec mat sunctx errCode f = do
+  let create = do
+        ls@(SUNLinearSolver ptr) <- cSUNLinSol_KLU vec mat sunctx
+
+        when (ptr == nullPtr) $ do
+          throwIO $ ReturnCode $ fromIntegral errCode
+
+        pure ls
+  bracket create cSUNLinSolFree f
+
+foreign import ccall "ARKodeEvolve" cARKodeEvolve :: ARKodeMem -> CDouble -> N_Vector -> Ptr CDouble -> CInt -> IO CInt
+
+foreign import ccall "ARKStepReInit"
+  cARKStepReInit ::
+    ARKodeMem ->
+    FunPtr OdeRhsCType ->
+    FunPtr a2 ->
+    CDouble ->
+    N_Vector ->
+    IO CInt
+
+foreign import ccall "ARKodeGetRootInfo" cARKodeGetRootInfo :: ARKodeMem -> Ptr CInt -> IO CInt
+
+foreign import ccall "ARKodeSetJacFn" cARKodeSetJacFn :: ARKodeMem -> FunPtr OdeJacobianCType -> IO CInt
+
+foreign import ccall "ARKodeSetFixedStep" cARKodeSetFixedStep :: ARKodeMem -> CDouble -> IO ()
+
+-- Note: the CInt are actually Enum and this could be enforced
+foreign import ccall "ARKStepSetTableNum" cARKStepSetTableNum :: ARKodeMem -> CInt -> CInt -> IO CInt
+
+-- | Opaque
+newtype SUNMatrix = SUNMatrix (Ptr Void)
+  deriving newtype (Storable)
+
+newtype SUNLinearSolver = SUNLinearSolver (Ptr Void)
+  deriving newtype (Storable)
+
+foreign import ccall "ARKodeGetNumSteps" cARKodeGetNumSteps :: ARKodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "ARKodeGetNumLinSolvSetups" cARKodeGetNumLinSolvSetups :: ARKodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "ARKodeGetNumErrTestFails" cARKodeGetNumErrTestFails :: ARKodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "ARKodeGetNumNonlinSolvIters" cARKodeGetNumNonlinSolvIters :: ARKodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "ARKodeGetNumNonlinSolvConvFails" cARKodeGetNumNonlinSolvConvFails :: ARKodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "ARKodeGetNumJacEvals" cARKodeGetNumJacEvals :: ARKodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "ARKStepGetNumRhsEvals" cARKStepGetNumRhsEvals :: ARKodeMem -> Ptr CLong -> Ptr CLong -> IO CInt
+
+foreign import ccall "ARKodeGetNumLinRhsEvals" cARKodeGetNumLinRhsEvals :: ARKodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "ARKodeGetNumStepAttempts" cARKodeGetNumStepAttempts :: ARKodeMem -> Ptr CLong -> IO CInt
+
+cvGet :: (HasCallStack) => (Storable b) => (ARKodeMem -> Ptr b -> IO CInt) -> ARKodeMem -> IO b
+cvGet getter cvode_mem = do
+  alloca $ \ptr -> do
+    err <- getter cvode_mem ptr
+    when (err /= ARK_SUCCESS) $ do
+      error $ "Failure during cvGet"
+    peek ptr
+
+foreign import ccall "ARKodeGetEstLocalErrors" cARKodeGetEstLocalErrors :: ARKodeMem -> N_Vector -> IO CInt
+
+foreign import ccall "ARKodeGetErrWeights" cARKodeGetErrWeights :: ARKodeMem -> N_Vector -> IO CInt
+
+foreign import ccall "SUNContext_ClearErrHandlers" cSUNContext_ClearErrHandlers :: SUNContext -> IO CInt
+
+foreign import ccall "N_VGetArrayPointer" cN_VGetArrayPointer :: N_Vector -> IO (Ptr CDouble)

--- a/src/Numeric/Sundials/CVode.hs
+++ b/src/Numeric/Sundials/CVode.hs
@@ -1,446 +1,458 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
 -- | Solution of ordinary differential equation (ODE) initial value problems.
 --
 -- <https://computation.llnl.gov/projects/sundials/sundials-software>
 module Numeric.Sundials.CVode
-  ( CVMethod(..)
-  , solveC
-  ) where
+  ( CVMethod (..),
+    solveC,
+  )
+where
 
-import qualified Language.C.Inline as C
+import Control.Exception
+import Control.Monad (when)
+import Control.Monad.State
+import Data.Bool
+import Data.Maybe (fromMaybe)
 import qualified Data.Vector.Storable as VS
-import Foreign.C.Types
-import GHC.Prim
+import qualified Data.Vector.Storable.Mutable as VSM
+import Data.Void
+import Foreign
+import Foreign.C
 import GHC.Generics
+import GHC.Prim
+import GHC.Stack
 import Katip
-
-import Numeric.Sundials.Foreign
 import Numeric.Sundials.Common
-import Foreign.Ptr
-
-C.context (C.baseCtx <> C.vecCtx <> C.funCtx <> sunCtx)
-
-C.include "<stdlib.h>"
-C.include "<stdio.h>"
-C.include "<string.h>"
-C.include "<math.h>"
-C.include "<arkode/arkode.h>"
-C.include "<cvode/cvode.h>"
-C.include "<nvector/nvector_serial.h>"
-C.include "<sunmatrix/sunmatrix_dense.h>"
-C.include "<sunlinsol/sunlinsol_dense.h>"
-C.include "<sunlinsol/sunlinsol_klu.h>"
-C.include "<sundials/sundials_types.h>"
-C.include "<sundials/sundials_types_deprecated.h>"
-C.include "<sundials/sundials_math.h>"
-C.include "<sundials/sundials_core.h>"
-C.include "../../helpers.h"
+import Numeric.Sundials.Foreign
+import Text.Printf (printf)
 
 -- | Available methods for CVode
-data CVMethod = ADAMS
-              | BDF
+data CVMethod
+  = ADAMS
+  | BDF
   deriving (Eq, Ord, Show, Read, Generic, Bounded, Enum)
 
 instance IsMethod CVMethod where
   methodToInt ADAMS = cV_ADAMS
-  methodToInt BDF   = cV_BDF
+  methodToInt BDF = cV_BDF
   methodType _ = Implicit
 
+-- Tries to copy the previous semantic in C when we had:
+data ReturnCode
+  = -- return, with error code, skipping finish (diagnostics and cleanup)
+    ReturnCode Int
+  | -- return with log message, skipping finish (diags and cleanup)
+    ReturnCodeWithMessage String Int
+  | -- "goto" finish (do diag and cleanup)
+    Finish LoopState
+  | -- break the loop, hence go to finish (do diag and cleanup)
+    Break LoopState
+  deriving (Exception, Show)
+
+-- | The loop state, most could be just carried by recursive function call, but
+-- the C semantic was kinda interleaved, so doing that for now.
+data LoopState = LoopState
+  { -- output_ind tracks the current row into the c_output_mat matrix.
+    -- if differs from input_ind because of the extra rows corresponding to events.
+    output_ind :: Int,
+    -- input_ind tracks the current index into the c_sol_time array
+    input_ind :: Int,
+    -- event_ind tracks the current event number
+    event_ind :: Int,
+    t_start :: CDouble
+  }
+  deriving (Show)
+
+foreign import ccall "wrapper"
+  mkReport :: ReportErrorFnNew -> IO (FunPtr ReportErrorFnNew)
+
 solveC :: Ptr CInt -> CConsts -> CVars (VS.MVector RealWorld) -> LogEnv -> IO CInt
-solveC ptrStop CConsts{..} CVars{..} log_env =
-  let
-    report_error = reportErrorWithKatip log_env
-    report_error_new_api = wrapErrorNewApi (reportErrorWithKatip log_env)
-    debug = debugMsgWithKatip log_env
-  in do
+solveC _ptrStop CConsts {..} CVars {..} log_env =
+  let report_error_new_api = wrapErrorNewApi (reportErrorWithKatip log_env)
+      debug :: String -> StateT LoopState IO ()
+      debug _s = do
+        -- This SPAMs the logging system with a lot of informations, so we do
+        -- not enable it by default
+        -- Just comment in/out this line for now, we'll think about a nicer solution later
+        -- liftIO (debugMsgWithKatip log_env s)
+        pure ()
+   in do
+        -- Allocate the error reporting callback
+        bracket (mkReport report_error_new_api) freeHaskellFunPtr $ \c_report_error -> do
+          withSUNContext $ \sunctx -> do
+            let init_loop =
+                  ( LoopState
+                      { -- /* input_ind tracks the current index into the c_sol_time array */
+                        input_ind = 1,
+                        -- /* output_ind tracks the current row into the c_output_mat matrix.
+                        --    If differs from input_ind because of the extra rows corresponding to events. */
+                        output_ind = 1,
+                        -- /* event_ind tracks the current event number */
+                        event_ind = 0,
+                        -- /* t_start tracks the starting point of the integration in order to detect
+                        --    empty integration interval and avoid a potential infinite loop;
+                        --    see Note [CV_TOO_CLOSE]. Unlike T0, t_start is updated every time we
+                        --    restart the solving after handling (or not) an event, or emitting
+                        --    a requested time point.
+                        --    Why not just look for the last recorded time in c_output_mat? Because
+                        --    an event may have eventRecord = False and not be present there.
+                        -- \*/
+                        t_start = t0
+                      }
+                  )
 
-  [C.block| int {
-  /* general problem variables */
+                t0 = fromMaybe (error "no t0") $ c_sol_time VS.!? 0
 
-  int flag;                  /* reusable error-checking flag                 */
-  int retval = CV_SUCCESS;
+            -- /* We need to update c_n_rows every time we update output_ind because
+            --    of the possibility of early return (in which case we still need to assemble
+            --    the partial results matrix). We could even work with c_n_rows only and ditch
+            --    output_ind, but the inline-c expression is quite verbose, and output_ind is
+            --    more convenient to use in index calculations.
+            -- \*/
+            VSM.write c_n_rows 0 (fromIntegral init_loop.output_ind)
 
-  int i, j;                  /* reusable loop indices                        */
-  N_Vector y = NULL;         /* empty vector for storing solution            */
-  N_Vector tv = NULL;        /* empty vector for storing absolute tolerances */
+            -- /* general problem parameters */
 
-  SUNMatrix A = NULL;        /* empty matrix for linear solver               */
-  SUNLinearSolver LS = NULL; /* empty linear solver object                   */
-  void *cvode_mem = NULL;    /* empty CVODE memory structure                 */
-  realtype t;
-  long int nst, nfe, nsetups, nje, nfeLS, nni, ncfn, netf;
-  SUNContext sunctx;
+            -- /* Initialize data structures */
 
-  SUNContext_Create(SUN_COMM_NULL, &sunctx);
 
-  /* input_ind tracks the current index into the c_sol_time array */
-  int input_ind = 1;
-  /* output_ind tracks the current row into the c_output_mat matrix.
-     If differs from input_ind because of the extra rows corresponding to events. */
-  int output_ind = 1;
-  /* We need to update c_n_rows every time we update output_ind because
-     of the possibility of early return (in which case we still need to assemble
-     the partial results matrix). We could even work with c_n_rows only and ditch
-     output_ind, but the inline-c expression is quite verbose, and output_ind is
-     more convenient to use in index calculations.
-  */
-  ($vec-ptr:(int *c_n_rows))[0] = output_ind;
-  /* event_ind tracks the current event number */
-  int event_ind = 0;
+            -- /* Initialize odeMaxEventsReached to False */
+            VSM.write c_diagnostics 10 0
 
-  /* general problem parameters */
+            -- /* Create serial vector for solution */
+            withNVector_Serial c_dim sunctx 6896 $ \y -> do
+              -- /* Specify initial condition */
+              VS.imapM_ (\i v -> cNV_Ith_S y i v) c_init_cond
 
-  realtype T0 = RCONST(($vec-ptr:(double *c_sol_time))[0]); /* initial time              */
-  sunindextype c_dim = $(sunindextype c_dim);           /* number of dependent vars. */
+              -- // NB: Uses the Newton solver by default
+              withCVodeMem c_method sunctx 8396 $ \cvode_mem -> do
+                cCVodeInit cvode_mem c_rhs t0 y >>= check 1960
 
-  /* t_start tracks the starting point of the integration in order to detect
-     empty integration interval and avoid a potential infinite loop;
-     see Note [CV_TOO_CLOSE]. Unlike T0, t_start is updated every time we
-     restart the solving after handling (or not) an event, or emitting
-     a requested time point.
-     Why not just look for the last recorded time in c_output_mat? Because
-     an event may have eventRecord = False and not be present there.
-  */
-  double t_start = T0;
+                -- /* Set the error handler */
+                cSUNContext_ClearErrHandlers sunctx >>= check 1093
+                cSUNContext_PushErrHandler sunctx c_report_error nullPtr >>= check 1093
 
-  /* Initialize data structures */
+                when (c_fixedstep > 0.0) $ do
+                  throwIO $ ReturnCodeWithMessage "fixedStep cannot be used with CVode" 6426
 
-  void (*report_error)(int,const char*, const char*, char*, void*) = $fun:(void (*report_error)(int,const char*, const char*, char*, void*));
-  void (*debug)(char*) = $fun:(void (*debug)(char*));
+                -- /* Set the user data */
+                cCVodeSetUserData cvode_mem c_rhs_userdata >>= check 1949
 
-  if ($(double c_fixedstep) > 0.0) {
-    report_error(0, "hmatrix-sundials", "solveC", "fixedStep cannot be used with CVode", NULL);
-    return 6426;
-  }
+                -- /* Create serial vector for absolute tolerances */
+                withNVector_Serial c_dim sunctx 6471 $ \tv -> do
+                  -- /* Specify tolerances */
+                  VS.imapM_ (\i v -> cNV_Ith_S tv i v) c_atol
 
-  /* Initialize odeMaxEventsReached to False */
-  ($vec-ptr:(sunindextype *c_diagnostics))[10] = 0;
+                  cCVodeSetMinStep cvode_mem c_minstep >>= check 6433
+                  cCVodeSetMaxNumSteps cvode_mem c_max_n_steps >>= check 9904
+                  cCVodeSetMaxErrTestFails cvode_mem c_max_err_test_fails >>= check 2512
 
-  y = N_VNew_Serial(c_dim, sunctx); /* Create serial vector for solution */
-  if (check_flag((void *)y, "N_VNew_Serial", 0, report_error)) return 6896;
-  /* Specify initial condition */
-  for (i = 0; i < c_dim; i++) {
-    NV_Ith_S(y,i) = ($vec-ptr:(double *c_init_cond))[i];
-  };
+                  -- /* Specify the scalar relative tolerance and vector absolute tolerances */
+                  cCVodeSVtolerances cvode_mem c_rtol tv >>= check 6212
 
-  // NB: Uses the Newton solver by default
-  cvode_mem = CVodeCreate($(int c_method), sunctx);
-  if (check_flag((void *)cvode_mem, "CVodeCreate", 0, report_error)) return(8396);
-  flag = CVodeInit(cvode_mem, $(int (* c_rhs) (realtype, N_Vector, N_Vector, UserData*)), T0, y);
-  if (check_flag(&flag, "CVodeInit", 1, report_error)) return(1960);
+                  -- /* Specify the root function */
+                  cCVodeRootInit cvode_mem c_n_event_specs c_event_fn >>= check 6290
+                  -- /* Disable the inactive roots warning; see https://git.novadiscovery.net/jinko/jinko/-/issues/2368 */
+                  cCVodeSetNoInactiveRootWarn cvode_mem >>= check 6291
 
-  /* Set the error handler */
-  SUNContext_ClearErrHandlers(sunctx);
+                  -- /* Initialize a jacobian matrix and solver */
+                  let withLinearSolver f = do
+                        if (c_sparse_jac /= 0)
+                          then do
+                            withSUNSparseMatrix c_dim c_dim c_sparse_jac CSC_MAT sunctx 9061 $ \a -> do
+                              withSUNLinSol_KLU y a sunctx 9316 $ \ls -> do
+                                -- /* Attach matrix and linear solver */
+                                cCVodeSetLinearSolver cvode_mem ls a >>= check 2625
+                                f
+                          else do
+                            withSUNDenseMatrix c_dim c_dim sunctx 9316 $ \a -> do
+                              withSUNLinSol_Dense y a sunctx 9316 $ \ls -> do
+                                -- /* Attach matrix and linear solver */
+                                cCVodeSetLinearSolver cvode_mem ls a >>= check 2625
+                                f
 
-  SUNErrHandlerFn report_error_new_api = (SUNErrHandlerFn) $fun:(void (*report_error_new_api)(int,const char*, const char*, const char*, int, void*, void *));
-  flag = SUNContext_PushErrHandler(sunctx, report_error_new_api, NULL);
-  if (check_flag(&flag, "CVodeSetErrHandlerFn", 1, report_error)) return 1093;
+                  withLinearSolver $ do
+                    -- /* Set the initial step size if there is one */
+                    when (c_init_step_size_set /= 0) $ do
+                      --   /* FIXME: We could check if the initial step size is 0 */
+                      --   /* or even NaN and then throw an error                 */
+                      cCVodeSetInitStep cvode_mem c_init_step_size >>= check 4010
 
-  /* Set the user data */
-  flag = CVodeSetUserData(cvode_mem, $(UserData* c_rhs_userdata));
-  if (check_flag(&flag, "CVodeSetUserData", 1, report_error)) return(1949);
+                    -- /* Set the Jacobian if there is one */
+                    when (c_jac_set /= 0) $ do
+                      cCVodeSetJacFn cvode_mem c_jac >>= check 3124
 
-  tv = N_VNew_Serial(c_dim, sunctx); /* Create serial vector for absolute tolerances */
-  if (check_flag((void *)tv, "N_VNew_Serial", 0, report_error)) return 6471;
-  /* Specify tolerances */
-  for (i = 0; i < c_dim; i++) {
-    NV_Ith_S(tv,i) = ($vec-ptr:(double *c_atol))[i];
-  };
+                    -- /* Store initial conditions */
+                    VSM.write c_output_mat (0 * (fromIntegral c_dim + 1) + 0) (c_sol_time VS.! 0)
+                    let go j
+                          | j == c_dim = pure ()
+                          | otherwise = do
+                              VSM.write c_output_mat (0 * fromIntegral (c_dim + 1) + (fromIntegral j + 1)) =<< cNV_Ith_S' y (fromIntegral j)
+                              go (j + 1)
+                    go 0
 
-  flag = CVodeSetMinStep(cvode_mem, $(double c_minstep));
-  if (check_flag(&flag, "CVodeSetMinStep", 1, report_error)) return 6433;
-  flag = CVodeSetMaxNumSteps(cvode_mem, $(sunindextype c_max_n_steps));
-  if (check_flag(&flag, "CVodeSetMaxNumSteps", 1, report_error)) return 9904;
-  flag = CVodeSetMaxErrTestFails(cvode_mem, $(int c_max_err_test_fails));
-  if (check_flag(&flag, "CVodeSetMaxErrTestFails", 1, report_error)) return 2512;
+                    c_ontimepoint (fromIntegral init_loop.output_ind)
 
-  /* Specify the scalar relative tolerance and vector absolute tolerances */
-  flag = CVodeSVtolerances(cvode_mem, $(double c_rtol), tv);
-  if (check_flag(&flag, "CVodeSVtolerances", 1, report_error)) return(6212);
+                    let loop :: StateT LoopState IO ()
+                        loop = do
+                          s <- get
+                          let ti = fromMaybe (error "Incorrect c_sol_time access") $ c_sol_time VS.!? s.input_ind
 
-  /* Specify the root function */
-  flag = CVodeRootInit(cvode_mem, $(int c_n_event_specs), $(int (* c_event_fn) (realtype, N_Vector, realtype*, UserData*)));
-  if (check_flag(&flag, "CVodeRootInit", 1, report_error)) return(6290);
-  /* Disable the inactive roots warning; see https://git.novadiscovery.net/jinko/jinko/-/issues/2368 */
-  flag = CVodeSetNoInactiveRootWarn(cvode_mem);
-  if (check_flag(&flag, "CVodeSetNoInactiveRootWarn", 1, report_error)) return(6291);
+                          next_time_event <- liftIO c_next_time_event
 
-  /* Initialize a jacobian matrix and solver */
-  int c_sparse_jac = $(int c_sparse_jac);
-  if (c_sparse_jac) {
-    A = SUNSparseMatrix(c_dim, c_dim, c_sparse_jac, CSC_MAT, sunctx);
-    if (check_flag((void *)A, "SUNSparseMatrix", 0, report_error)) return 9061;
-    LS = SUNLinSol_KLU(y, A, sunctx);
-    if (check_flag((void *)LS, "SUNLinSol_KLU", 0, report_error)) return 9316;
-  } else {
-    A = SUNDenseMatrix(c_dim, c_dim, sunctx);
-    if (check_flag((void *)A, "SUNDenseMatrix", 0, report_error)) return 9061;
-    LS = SUNLinSol_Dense(y, A, sunctx);
-    if (check_flag((void *)LS, "SUNLinSol_Dense", 0, report_error)) return 9316;
-  }
+                          --   // Haskell failure in the next time event function
+                          when (next_time_event == -1) $ do
+                            s <- get
+                            liftIO $ throwIO $ Break s
 
-  /* Attach matrix and linear solver */
-  flag = CVodeSetLinearSolver(cvode_mem, LS, A);
-  if (check_flag(&flag, "CVodeSetLinearSolver", 1, report_error)) return 2625;
+                          when (next_time_event < s.t_start) $ do
+                            s <- get
+                            debug $ printf "time-based event is in the past: next event time = %.4f while we are at %.4f" (coerce next_time_event :: Double) (coerce s.t_start :: Double)
+                            liftIO $ throwIO $ Finish s
 
-  /* Set the initial step size if there is one */
-  if ($(int c_init_step_size_set)) {
-    /* FIXME: We could check if the initial step size is 0 */
-    /* or even NaN and then throw an error                 */
-    flag = CVodeSetInitStep(cvode_mem, $(double c_init_step_size));
-    if (check_flag(&flag, "CVodeSetInitStep", 1, report_error)) return 4010;
-  }
+                          let next_stop_time = min ti next_time_event
+                          debug $ printf "Main loop iteration: t = %.17g (%a), next time point (ti) = %.17g, next time event = %.17g" (coerce s.t_start :: Double) (coerce ti :: Double) (coerce next_time_event :: Double)
+                          (t, flag) <- liftIO $ alloca $ \t_ptr -> do
+                            flag <- cCVode cvode_mem next_stop_time y t_ptr CV_NORMAL
+                            t <- peek t_ptr
+                            pure (t, flag)
 
-  /* Set the Jacobian if there is one */
-  if ($(int c_jac_set)) {
-    CVLsJacFn c_jac = $(int (*c_jac)(realtype, N_Vector, N_Vector, SUNMatrix, UserData*, N_Vector, N_Vector, N_Vector));
-    flag = CVodeSetJacFn(cvode_mem, c_jac);
-    if (check_flag(&flag, "CVodeSetJacFn", 1, report_error)) return 3124;
-  }
+                          debug $ printf "CVode returned %d; now t = %.17g\n" (fromIntegral flag :: Int) (coerce t :: Double)
+                          let root_based_event = flag == CV_ROOT_RETURN
+                          let time_based_event = t == next_time_event
+                          (t, _flag) <-
+                            if flag == CV_TOO_CLOSE && not time_based_event
+                              then do
+                                --     /* See Note [CV_TOO_CLOSE]
+                                --        No solving was required; just set the time t manually and continue
+                                --        as if solving succeeded. */
+                                debug $ printf "Got CV_TOO_CLOSE; no solving was required; proceeding to t = %.17g" (coerce next_stop_time :: Double)
+                                pure (next_stop_time, flag)
+                              else do
+                                s <- get
+                                if t == next_stop_time && t == s.t_start && flag == CV_ROOT_RETURN && not time_based_event
+                                  then do
+                                    --     /* See Note [CV_TOO_CLOSE]
+                                    --        Probably the initial step size was set, and that's why we didn't
+                                    --        get CV_TOO_CLOSE.
+                                    --        Pretend that the root didn't happen, lest we keep handling it
+                                    --        forever. */
+                                    debug $ ("Got a root but t == t_start == next_stop_time; pretending it didn't happen" :: String)
+                                    pure (t, CV_SUCCESS)
+                                  else do
+                                    if not (flag == CV_TOO_CLOSE && time_based_event) && flag < 0
+                                      then do
+                                        liftIO $ withNVector_Serial c_dim sunctx 12341234 $ \ele -> do
+                                          liftIO $ withNVector_Serial c_dim sunctx 12341234 $ \weights -> do
+                                            flag <- liftIO $ cCVodeGetEstLocalErrors cvode_mem ele
+                                            flag' <- liftIO $ cCVodeGetErrWeights cvode_mem weights
+                                            when (flag == CV_SUCCESS && flag' == CV_SUCCESS) $ do
+                                              let go ix destination source
+                                                    | ix == c_dim = pure ()
+                                                    | otherwise = do
+                                                        v <- peekElemOff source (fromIntegral ix)
+                                                        VSM.write destination (fromIntegral ix) v
+                                                        go (ix + 1) destination source
+                                              go 0 c_local_error =<< cN_VGetArrayPointer ele
+                                              go 0 c_var_weight =<< cN_VGetArrayPointer weights
 
-  /* Store initial conditions */
-  ($vec-ptr:(double *c_output_mat))[0 * (c_dim + 1) + 0] = ($vec-ptr:(double *c_sol_time))[0];
-  for (j = 0; j < c_dim; j++) {
-    ($vec-ptr:(double *c_output_mat))[0 * (c_dim + 1) + (j + 1)] = NV_Ith_S(y,j);
-  }
+                                              VSM.write c_local_error_set 0 1
+                                            liftIO $ throwIO (ReturnCode 45)
+                                      else pure (t, flag)
 
-  $fun:(void (*c_ontimepoint)(int))(output_ind);
+                          --   /* Store the results for Haskell */
+                          s <- get
+                          VSM.write c_output_mat (s.output_ind * (fromIntegral c_dim + 1) + 0) t
+                          let go j
+                                | j == c_dim = pure ()
+                                | otherwise = do
+                                    liftIO $ VSM.write c_output_mat (s.output_ind * fromIntegral (c_dim + 1) + (fromIntegral j + 1)) =<< cNV_Ith_S' y (fromIntegral j)
+                                    go (j + 1)
+                          go 0
 
-  while (1) {
-     // The solver will run until it terminates or receive a signal to stop by the
-     // way of a non null value in *ptrSTop
-     // The signal is an exception from outside (see the solve function in
-     // Numeric/Sundials.hs
-    // Ensure proper memory barrier.
-    // This cannot be simply replaced by if(*ptrStop) because the compiler is free to consider ptrStop as a constant for the complete loop execution.
-    // So instead, we use __atomic_load to force the load
-    int stopFlag = 0;
-    __atomic_load($(int* ptrStop), &stopFlag, __ATOMIC_SEQ_CST);
+                          s <- get
+                          liftIO $ c_ontimepoint (fromIntegral s.output_ind)
+                          modify $ \s -> s {output_ind = s.output_ind + 1}
 
-    if(stopFlag)
-    {
-      break;
-    }
+                          s <- get
+                          VSM.write c_n_rows 0 (fromIntegral s.output_ind)
 
-    double ti = ($vec-ptr:(double *c_sol_time))[input_ind];
-    double next_time_event = ($fun:(double (*c_next_time_event)()))();
+                          when (root_based_event || time_based_event) $ do
+                            debug ("Got an event")
+                            when (fromIntegral s.event_ind >= c_max_events) $ do
+                              debug ("Maximum number of events reached")
+                              --       /* We reached the maximum number of events.
+                              --          Either the maximum number of events is set to 0,
+                              --          or there's a bug in our code below. In any case return an error.
+                              --       */
+                              liftIO $ throwIO (ReturnCode 8630)
 
-    // Haskell failure in the next time event function
-    if(next_time_event == -1)
-      break;
+                            --     /* How many events triggered? */
+                            n_events_triggered <-
+                              if not root_based_event
+                                then pure 0
+                                else do
+                                  debug ("Handling root-based events")
+                                  liftIO $ VSM.unsafeWith c_root_info $ \c_root_info_ptr -> do
+                                    flag <- cCVodeGetRootInfo cvode_mem c_root_info_ptr
+                                    when (flag < 0) $ do
+                                      throwIO $ ReturnCode 2829
+                                    let go i n_events_triggered
+                                          | i >= c_n_event_specs = pure n_events_triggered
+                                          | otherwise = do
+                                              ev <- VSM.read c_root_info (fromIntegral i)
+                                              let req_dir = c_requested_event_direction VS.! (fromIntegral i)
 
-    if (next_time_event < t_start) {
-      size_t msg_size = 1000;
-      char *msg = alloca(msg_size);
-      snprintf(msg, msg_size, "time-based event is in the past: next event time = %.4f while we are at %.4f", next_time_event, t_start);
-      report_error(0, "hmatrix-sundials", "solveC", msg, NULL);
-      retval = 5669;
-      goto finish;
-    }
-    double next_stop_time = fmin(ti, next_time_event);
-    DEBUG("Main loop iteration: t = %.17g (%a), next time point (ti) = %.17g, next time event = %.17g", t, ti, next_time_event);
-    flag = CVode(cvode_mem, next_stop_time, y, &t, CV_NORMAL); /* call integrator */
-    DEBUG("CVode returned %d; now t = %.17g\n", flag, t);
-    int root_based_event = flag == CV_ROOT_RETURN;
-    int time_based_event = t == next_time_event;
-    if (flag == CV_TOO_CLOSE && !time_based_event) {
-      /* See Note [CV_TOO_CLOSE]
-         No solving was required; just set the time t manually and continue
-         as if solving succeeded. */
-      DEBUG("Got CV_TOO_CLOSE; no solving was required; proceeding to t = %.17g", next_stop_time);
-      t = next_stop_time;
-    }
-    else
-    if (t == next_stop_time && t == t_start && flag == CV_ROOT_RETURN && !time_based_event) {
-      /* See Note [CV_TOO_CLOSE]
-         Probably the initial step size was set, and that's why we didn't
-         get CV_TOO_CLOSE.
-         Pretend that the root didn't happen, lest we keep handling it
-         forever. */
-      DEBUG("Got a root but t == t_start == next_stop_time; pretending it didn't happen");
-      flag = CV_SUCCESS;
-    }
-    else
-    if (!(flag == CV_TOO_CLOSE && time_based_event) &&
-      check_flag(&flag, "CVode", 1, report_error)) {
+                                              if ev /= 0 && ev * req_dir >= 0
+                                                then do
+                                                  --           /* After the above call to CVodeGetRootInfo, c_root_info has an
+                                                  --           entry per EventSpec. Here we reuse the same array but convert it
+                                                  --           into one that contains indices of triggered events. */
+                                                  --           c_root_info[n_events_triggered++] = i;
+                                                  VSM.write c_root_info n_events_triggered i
+                                                  go (i + 1) (n_events_triggered + 1)
+                                                else do
+                                                  go (i + 1) n_events_triggered
+                                    go 0 0
 
-      N_Vector ele = N_VNew_Serial(c_dim, sunctx);
-      N_Vector weights = N_VNew_Serial(c_dim, sunctx);
-      flag = CVodeGetEstLocalErrors(cvode_mem, ele);
-      // CV_SUCCESS is defined is 0, so we OR the flags
-      flag = flag || CVodeGetErrWeights(cvode_mem, weights);
-      if (flag == CV_SUCCESS) {
-        double *arr_ptr = N_VGetArrayPointer(ele);
-        memcpy(($vec-ptr:(double *c_local_error)), arr_ptr, c_dim * sizeof(double));
+                            (record_events, stop_solver) <-
+                              if (n_events_triggered > 0 || time_based_event)
+                                then do
+                                  debug $ printf "Calling the event handler; n_events_triggered = %d; time_based_event = %d" n_events_triggered (bool (0 :: Int) 1 time_based_event)
+                                  (stop_solver, record_events, err) <- liftIO $ alloca $ \stop_solver_ptr -> alloca $ \record_event_ptr -> do
+                                    --       /* Update the state with the supplied function */
+                                    err <- VSM.unsafeWith c_root_info $ \c_root_info_ptr -> do
+                                      err <- c_apply_event (fromIntegral n_events_triggered) c_root_info_ptr t (coerce y) (coerce y) stop_solver_ptr record_event_ptr
+                                      pure err
+                                    stop_solver <- peek stop_solver_ptr
+                                    record_event <- peek record_event_ptr
+                                    pure (stop_solver, record_event, err)
 
-        arr_ptr = N_VGetArrayPointer(weights);
-        memcpy(($vec-ptr:(double *c_var_weight)), arr_ptr, c_dim * sizeof(double));
+                                  --       // If the event handled failed internally, we stop the solving
+                                  when (err /= 0) $ do
+                                    s <- get
+                                    liftIO $ throwIO $ Break s
 
-        ($vec-ptr:(int *c_local_error_set))[0] = 1;
-      }
-      N_VDestroy(ele);
-      N_VDestroy(weights);
-      return 45;
-    }
+                                  pure (record_events, stop_solver)
+                                else pure (0, 0)
 
-    /* Store the results for Haskell */
-    ($vec-ptr:(double *c_output_mat))[output_ind * (c_dim + 1) + 0] = t;
-    for (j = 0; j < c_dim; j++) {
-      ($vec-ptr:(double *c_output_mat))[output_ind * (c_dim + 1) + (j + 1)] = NV_Ith_S(y,j);
-    }
+                            if record_events /= 0
+                              then do
+                                debug ("Recording events")
+                                --       /* A corner case: if the time-based event triggers at the very beginning,
+                                --          then we don't want to duplicate the initial row, so rewind it back.
+                                --          Note that we do this only in the branch where record_events is true;
+                                --          otherwise we may end up erasing the initial row (see below). */
+                                s <- get
+                                when (t == c_sol_time VS.! 0 && s.output_ind == 2) $ do
+                                  --         /* c_n_rows will be updated below anyway */
+                                  modify $ \s -> s {output_ind = s.output_ind - 1}
 
-    $fun:(void (*c_ontimepoint)(int))(output_ind);
+                                s <- get
+                                VSM.write c_output_mat (s.output_ind * (fromIntegral c_dim + 1) + 0) t
+                                let go j
+                                      | j == c_dim = pure ()
+                                      | otherwise = do
+                                          liftIO $ VSM.write c_output_mat (s.output_ind * fromIntegral (c_dim + 1) + (fromIntegral j + 1)) =<< cNV_Ith_S' y (fromIntegral j)
+                                          go (j + 1)
+                                go 0
 
-    output_ind++;
-    ($vec-ptr:(int *c_n_rows))[0] = output_ind;
+                                s <- get
+                                liftIO $ c_ontimepoint $ fromIntegral s.output_ind
+                                modify $ \s -> s {event_ind = s.event_ind + 1, output_ind = s.output_ind + 1}
+                                s <- get
+                                VSM.write c_n_rows 0 (fromIntegral s.output_ind)
+                              else do
+                                --       /* Remove the saved row — unless the event time also coincides with a requested time point */
+                                when (t /= ti) $ do
+                                  modify $ \s -> s {output_ind = s.output_ind - 1}
+                                  s <- get
+                                  VSM.write c_n_rows 0 (fromIntegral s.output_ind)
+                            s <- get
+                            stop_solver <-
+                              if (fromIntegral s.event_ind >= c_max_events)
+                                then do
+                                  debug ("Reached max_events; returning")
+                                  VSM.write c_diagnostics 10 1
+                                  pure 1
+                                else pure stop_solver
+                            when (stop_solver /= 0) $ do
+                              debug ("Stopping the hmatrix-sundials solver as requested")
+                              s <- get
+                              liftIO $ throwIO $ Finish s
 
-    if (root_based_event || time_based_event) {
-      DEBUG("Got an event");
-      if (event_ind >= $(int c_max_events)) {
-        /* We reached the maximum number of events.
-           Either the maximum number of events is set to 0,
-           or there's a bug in our code below. In any case return an error.
-        */
-        DEBUG("Maximum number of events reached");
-        return 8630;
-      }
+                            when (n_events_triggered > 0 || time_based_event) $ do
+                              debug ("Re-initializing the system")
+                              liftIO $ cCVodeReInit cvode_mem t y
 
-      /* How many events triggered? */
-      int n_events_triggered = 0;
-      int *c_root_info = ($vec-ptr:(int *c_root_info));
-      if (root_based_event) {
-        DEBUG("Handling root-based events");
-        flag = CVodeGetRootInfo(cvode_mem, c_root_info);
-        if (check_flag(&flag, "CVodeGetRootInfo", 1, report_error)) return 2829;
-        for (i = 0; i < $(int c_n_event_specs); i++) {
-          int ev = c_root_info[i];
-          int req_dir = ($vec-ptr:(const int *c_requested_event_direction))[i];
-          if (ev != 0 && ev * req_dir >= 0) {
-            /* After the above call to CVodeGetRootInfo, c_root_info has an
-            entry per EventSpec. Here we reuse the same array but convert it
-            into one that contains indices of triggered events. */
-            c_root_info[n_events_triggered++] = i;
-          }
-        }
-      }
+                          when (t == ti) $ do
+                            modify $ \s -> s {input_ind = s.input_ind + 1}
+                            s <- get
+                            when (s.input_ind >= fromIntegral c_n_sol_times) $ do
+                              s <- get
+                              liftIO $ throwIO $ Finish s
 
-      /* Should we stop the solver? */
-      int stop_solver = 0;
-      /* Should we record the state before/after the event in the output matrix? */
-      int record_events = 0;
-      if (n_events_triggered > 0 || time_based_event) {
-        /* Update the state with the supplied function */
-        DEBUG("Calling the event handler; n_events_triggered = %d; time_based_event = %d", n_events_triggered, time_based_event);
-        int error = $fun:(int (* c_apply_event) (int, int*, double, N_Vector y, N_Vector z, int*, int*))(n_events_triggered, c_root_info, t, y, y, &stop_solver, &record_events);
+                          modify $ \s -> s {t_start = t}
+                          loop
+                    resM <- try $ execStateT loop init_loop
+                    case resM of
+                      Left (ReturnCode c)
+                        | c == fromIntegral CV_SUCCESS -> pure CV_SUCCESS
+                        | otherwise -> pure $ (fromIntegral c)
+                      Left (ReturnCodeWithMessage _message c)
+                        | c == fromIntegral CV_SUCCESS -> pure CV_SUCCESS
+                        | otherwise -> pure $ (fromIntegral c)
+                      Right finalState -> end cvode_mem finalState
+                      Left (Break finalState) -> end cvode_mem finalState
+                      Left (Finish finalState) -> end cvode_mem finalState
+  where
+    end cvode_mem finalState = do
+      -- /* The number of actual roots we found */
+      VSM.write c_n_events 0 (fromIntegral finalState.event_ind)
 
-        // If the event handled failed internally, we stop the solving
-        if(error)
-          break;
-      }
+      -- /* Get some final statistics on how the solve progressed */
+      nst <- cvGet cCVodeGetNumSteps cvode_mem
+      VSM.write c_diagnostics 0 (fromIntegral nst)
 
-      if (record_events) {
-        DEBUG("Recording events");
-        /* A corner case: if the time-based event triggers at the very beginning,
-           then we don't want to duplicate the initial row, so rewind it back.
-           Note that we do this only in the branch where record_events is true;
-           otherwise we may end up erasing the initial row (see below). */
-        if (t == ($vec-ptr:(double *c_sol_time))[0] && output_ind == 2) {
-          output_ind--;
-          /* c_n_rows will be updated below anyway */
-        }
+      -- /* FIXME */
+      VSM.write c_diagnostics 1 0
 
-        ($vec-ptr:(double *c_output_mat))[output_ind * (c_dim + 1) + 0] = t;
-        for (j = 0; j < c_dim; j++) {
-          ($vec-ptr:(double *c_output_mat))[output_ind * (c_dim + 1) + (j + 1)] = NV_Ith_S(y,j);
-        }
-        $fun:(void (*c_ontimepoint)(int))(output_ind);
+      nfe <- cvGet cCVodeGetNumRhsEvals cvode_mem
+      VSM.write c_diagnostics 2 (fromIntegral nfe)
 
-        event_ind++;
-        output_ind++;
-        ($vec-ptr:(int *c_n_rows))[0] = output_ind;
-      } else {
-        /* Remove the saved row — unless the event time also coincides with a requested time point */
-        if (t != ti) {
-          output_ind--;
-          ($vec-ptr:(int *c_n_rows))[0] = output_ind;
-        }
-      }
-      if (event_ind >= $(int c_max_events)) {
-        DEBUG("Reached max_events; returning");
-        ($vec-ptr:(sunindextype *c_diagnostics))[10] = 1;
-        stop_solver = 1;
-      }
-      if (stop_solver) {
-        DEBUG("Stopping the hmatrix-sundials solver as requested");
-        goto finish;
-      }
+      -- /* FIXME */
+      VSM.write c_diagnostics 3 0
 
-      if (n_events_triggered > 0 || time_based_event) {
-        DEBUG("Re-initializing the system");
-        flag = CVodeReInit(cvode_mem, t, y);
-        if (check_flag(&flag, "CVodeReInit", 1, report_error)) return(1576);
-      }
-    }
-    if (t == ti) {
-      if (++input_ind >= $(int c_n_sol_times))
-        goto finish;
-    }
-    t_start = t;
-  }
+      nsetups <- cvGet cCVodeGetNumLinSolvSetups cvode_mem
+      VSM.write c_diagnostics 4 (fromIntegral nsetups)
 
-  finish:
-  DEBUG("Cleaning up before returning from the hmatrix-sundials solver");
+      netf <- cvGet cCVodeGetNumErrTestFails cvode_mem
+      VSM.write c_diagnostics 5 (fromIntegral netf)
 
-  /* The number of actual roots we found */
-  ($vec-ptr:(int *c_n_events))[0] = event_ind;
+      nni <- cvGet cCVodeGetNumNonlinSolvIters cvode_mem
+      VSM.write c_diagnostics 6 (fromIntegral nni)
 
-  /* Get some final statistics on how the solve progressed */
-  flag = CVodeGetNumSteps(cvode_mem, &nst);
-  check_flag(&flag, "CVodeGetNumSteps", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[0] = nst;
+      ncfn <- cvGet cCVodeGetNumNonlinSolvConvFails cvode_mem
+      VSM.write c_diagnostics 7 (fromIntegral ncfn)
 
-  /* FIXME */
-  ($vec-ptr:(sunindextype *c_diagnostics))[1] = 0;
+      nje <- cvGet cCVodeGetNumJacEvals cvode_mem
+      VSM.write c_diagnostics 8 (fromIntegral nje)
 
-  flag = CVodeGetNumRhsEvals(cvode_mem, &nfe);
-  check_flag(&flag, "CVodeGetNumRhsEvals", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[2] = nfe;
-  /* FIXME */
-  ($vec-ptr:(sunindextype *c_diagnostics))[3] = 0;
+      nfeLS <- cvGet cCVodeGetNumLinRhsEvals cvode_mem
+      VSM.write c_diagnostics 9 (fromIntegral nfeLS)
 
-  flag = CVodeGetNumLinSolvSetups(cvode_mem, &nsetups);
-  check_flag(&flag, "CVodeGetNumLinSolvSetups", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[4] = nsetups;
+      pure CV_SUCCESS
 
-  flag = CVodeGetNumErrTestFails(cvode_mem, &netf);
-  check_flag(&flag, "CVodeGetNumErrTestFails", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[5] = netf;
+foreign import ccall "SUNContext_PushErrHandler" cSUNContext_PushErrHandler :: SUNContext -> FunPtr ReportErrorFnNew -> Ptr () -> IO CInt
 
-  flag = CVodeGetNumNonlinSolvIters(cvode_mem, &nni);
-  check_flag(&flag, "CVodeGetNumNonlinSolvIters", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[6] = nni;
-
-  flag = CVodeGetNumNonlinSolvConvFails(cvode_mem, &ncfn);
-  check_flag(&flag, "CVodeGetNumNonlinSolvConvFails", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[7] = ncfn;
-
-  flag = CVodeGetNumJacEvals(cvode_mem, &nje);
-  check_flag(&flag, "CVodeGetNumJacEvals", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[8] = nje;
-
-  flag = CVodeGetNumLinRhsEvals(cvode_mem, &nfeLS);
-  check_flag(&flag, "CVodeGetNumLinRhsEvals", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[9] = nfeLS;
-
-  /* Clean up and return */
-  N_VDestroy(y);          /* Free y vector          */
-  N_VDestroy(tv);         /* Free tv vector         */
-  CVodeFree(&cvode_mem);  /* Free integrator memory */
-  SUNLinSolFree(LS);      /* Free linear solver     */
-  SUNMatDestroy(A);       /* Free A matrix          */
-  SUNContext_Free(&sunctx);
-
-  return CV_SUCCESS;
- } |]
+--  |]
 
 {- Note [CV_TOO_CLOSE]
    ~~~~~~~~~~~~~~~~~~~
@@ -475,3 +487,205 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
    a time-based event, the next time-based event should be at a strictly
    later time.
 -}
+
+-- An opaque pointer to a SUNContext
+newtype SUNContext = SUNContext (Ptr Void)
+  deriving newtype (Storable)
+
+foreign import ccall "SUNGetErrMsg" cSUNGetErrMsg :: CInt -> IO CString
+
+withSUNContext :: (HasCallStack) => (SUNContext -> IO a) -> IO a
+withSUNContext cont = do
+  alloca $ \ptr -> do
+    let create = do
+          errCode <- cSUNContext_Create 0 ptr
+          when (errCode /= 0) $ do
+            errMsg <- cSUNGetErrMsg errCode
+            msg <- peekCString errMsg
+            error msg
+          pure ()
+        destroy = cSUNContext_Free ptr
+    bracket_ create destroy $ do
+      sunctx <- peek ptr
+      cont sunctx
+
+check :: (HasCallStack) => Int -> CInt -> IO ()
+check retCode status
+  | status == CV_SUCCESS = pure ()
+  | otherwise = throwIO (ReturnCode retCode)
+
+foreign import ccall "SUNContext_Create" cSUNContext_Create :: Int -> Ptr SUNContext -> IO CInt
+
+foreign import ccall "SUNContext_Free" cSUNContext_Free :: Ptr SUNContext -> IO CInt
+
+-- | An opaque pointer to a CVodeMem
+newtype CVodeMem = CVodeMem (Ptr Void)
+  deriving newtype (Storable)
+
+withCVodeMem :: (HasCallStack) => CInt -> SUNContext -> Int -> (CVodeMem -> IO a) -> IO a
+withCVodeMem method suncontext errCode f = do
+  let create = do
+        res@(CVodeMem ptr) <- cCVodeCreate method suncontext
+        if ptr == nullPtr
+          then throwIO $ ReturnCodeWithMessage "Error in cvodeCreate" errCode
+          else pure res
+      destroy p = do
+        with p cCVodeFree
+  bracket create destroy f
+
+foreign import ccall "CVodeCreate" cCVodeCreate :: CInt -> SUNContext -> IO CVodeMem
+
+foreign import ccall "CVodeFree" cCVodeFree :: Ptr CVodeMem -> IO ()
+
+foreign import ccall "CVodeInit" cCVodeInit :: CVodeMem -> FunPtr OdeRhsCType -> SunRealType -> N_Vector -> IO CInt
+
+-- | An opaque pointer to an N_Vector
+newtype N_Vector = N_Vector (Ptr Void)
+
+foreign import ccall "N_VNew_Serial" unsafeN_VNew_Serial :: SunIndexType -> SUNContext -> IO N_Vector
+
+foreign import ccall "N_VDestroy" unsafeN_VDestroy :: N_Vector -> IO ()
+
+withNVector_Serial :: SunIndexType -> SUNContext -> Int -> (N_Vector -> IO a) -> IO a
+withNVector_Serial t suncontext errCode f = do
+  let create = do
+        res@(N_Vector ptr) <- unsafeN_VNew_Serial t suncontext
+        when (ptr == nullPtr) $ do
+          throwIO $ ReturnCodeWithMessage "Failure in N_VNew_Serial" errCode
+        pure res
+  bracket create unsafeN_VDestroy f
+
+cNV_Ith_S :: N_Vector -> Int -> CDouble -> IO ()
+cNV_Ith_S (N_Vector ptr) i v = do
+  qtr <- getContentPtr ptr
+  rtr <- getData qtr
+  pokeElemOff rtr i v
+
+cNV_Ith_S' :: N_Vector -> Int -> IO CDouble
+cNV_Ith_S' (N_Vector ptr) i = do
+  qtr <- getContentPtr ptr
+  rtr <- getData qtr
+  peekElemOff rtr i
+
+foreign import ccall "CVodeSetUserData" cCVodeSetUserData :: CVodeMem -> Ptr UserData -> IO CInt
+
+foreign import ccall "CVodeSetMinStep" cCVodeSetMinStep :: CVodeMem -> CDouble -> IO CInt
+
+foreign import ccall "CVodeSetMaxNumSteps" cCVodeSetMaxNumSteps :: CVodeMem -> SunIndexType -> IO CInt
+
+foreign import ccall "CVodeSetMaxErrTestFails" cCVodeSetMaxErrTestFails :: CVodeMem -> CInt -> IO CInt
+
+foreign import ccall "CVodeSVtolerances" cCVodeSVtolerances :: CVodeMem -> CDouble -> N_Vector -> IO CInt
+
+foreign import ccall "CVodeRootInit" cCVodeRootInit :: CVodeMem -> CInt -> FunPtr EventConditionCType -> IO CInt
+
+foreign import ccall "CVodeSetNoInactiveRootWarn" cCVodeSetNoInactiveRootWarn :: CVodeMem -> IO CInt
+
+foreign import ccall "CVodeSetLinearSolver" cCVodeSetLinearSolver :: CVodeMem -> SUNLinearSolver -> SUNMatrix -> IO CInt
+
+foreign import ccall "CVodeSetInitStep" cCVodeSetInitStep :: CVodeMem -> CDouble -> IO CInt
+
+foreign import ccall "SUNSparseMatrix" cSUNSparseMatrix :: SunIndexType -> SunIndexType -> CInt -> CInt -> SUNContext -> IO SUNMatrix
+
+foreign import ccall "SUNLinSol_KLU" cSUNLinSol_KLU :: N_Vector -> SUNMatrix -> SUNContext -> IO SUNLinearSolver
+
+foreign import ccall "SUNDenseMatrix" cSUNDenseMatrix :: SunIndexType -> SunIndexType -> SUNContext -> IO SUNMatrix
+
+foreign import ccall "SUNLinSol_Dense" cSUNLinSol_Dense :: N_Vector -> SUNMatrix -> SUNContext -> IO SUNLinearSolver
+
+foreign import ccall "SUNMatDestroy" cSUNMatDestroy :: SUNMatrix -> IO ()
+
+foreign import ccall "SUNLinSolFree" cSUNLinSolFree :: SUNLinearSolver -> IO CInt
+
+withSUNDenseMatrix :: (HasCallStack) => SunIndexType -> SunIndexType -> SUNContext -> CInt -> (SUNMatrix -> IO a) -> IO a
+withSUNDenseMatrix dim dim' sunctx errCode f = do
+  let create = do
+        mat@(SUNMatrix ptr) <- cSUNDenseMatrix dim dim' sunctx
+
+        when (ptr == nullPtr) $ do
+          throwIO $ ReturnCode $ fromIntegral errCode
+
+        pure mat
+  bracket create cSUNMatDestroy f
+
+-- SUNLinSolFree ls
+
+withSUNSparseMatrix :: (HasCallStack) => SunIndexType -> SunIndexType -> CInt -> CInt -> SUNContext -> CInt -> (SUNMatrix -> IO a) -> IO a
+withSUNSparseMatrix dim dim' jac set sunctx errCode f = do
+  let create = do
+        mat@(SUNMatrix ptr) <- cSUNSparseMatrix dim dim' jac set sunctx
+
+        when (ptr == nullPtr) $ do
+          throwIO $ ReturnCode $ fromIntegral errCode
+
+        pure mat
+  bracket create cSUNMatDestroy f
+
+withSUNLinSol_Dense :: (HasCallStack) => N_Vector -> SUNMatrix -> SUNContext -> CInt -> (SUNLinearSolver -> IO a) -> IO a
+withSUNLinSol_Dense vec mat sunctx errCode f = do
+  let create = do
+        ls@(SUNLinearSolver ptr) <- cSUNLinSol_Dense vec mat sunctx
+
+        when (ptr == nullPtr) $ do
+          throwIO $ ReturnCode $ fromIntegral errCode
+
+        pure ls
+  bracket create cSUNLinSolFree f
+
+withSUNLinSol_KLU :: (HasCallStack) => N_Vector -> SUNMatrix -> SUNContext -> CInt -> (SUNLinearSolver -> IO a) -> IO a
+withSUNLinSol_KLU vec mat sunctx errCode f = do
+  let create = do
+        ls@(SUNLinearSolver ptr) <- cSUNLinSol_KLU vec mat sunctx
+
+        when (ptr == nullPtr) $ do
+          throwIO $ ReturnCode $ fromIntegral errCode
+
+        pure ls
+  bracket create cSUNLinSolFree f
+
+foreign import ccall "CVode" cCVode :: CVodeMem -> CDouble -> N_Vector -> Ptr CDouble -> CInt -> IO CInt
+
+foreign import ccall "CVodeReInit" cCVodeReInit :: CVodeMem -> CDouble -> N_Vector -> IO ()
+
+foreign import ccall "CVodeGetRootInfo" cCVodeGetRootInfo :: CVodeMem -> Ptr CInt -> IO CInt
+
+foreign import ccall "CVodeSetJacFn" cCVodeSetJacFn :: CVodeMem -> FunPtr OdeJacobianCType -> IO CInt
+
+-- | Opaque
+newtype SUNMatrix = SUNMatrix (Ptr Void)
+  deriving newtype (Storable)
+
+newtype SUNLinearSolver = SUNLinearSolver (Ptr Void)
+  deriving newtype (Storable)
+
+foreign import ccall "CVodeGetNumSteps" cCVodeGetNumSteps :: CVodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "CVodeGetNumLinSolvSetups" cCVodeGetNumLinSolvSetups :: CVodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "CVodeGetNumErrTestFails" cCVodeGetNumErrTestFails :: CVodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "CVodeGetNumNonlinSolvIters" cCVodeGetNumNonlinSolvIters :: CVodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "CVodeGetNumNonlinSolvConvFails" cCVodeGetNumNonlinSolvConvFails :: CVodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "CVodeGetNumJacEvals" cCVodeGetNumJacEvals :: CVodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "CVodeGetNumRhsEvals" cCVodeGetNumRhsEvals :: CVodeMem -> Ptr CLong -> IO CInt
+
+foreign import ccall "CVodeGetNumLinRhsEvals" cCVodeGetNumLinRhsEvals :: CVodeMem -> Ptr CLong -> IO CInt
+
+cvGet :: (HasCallStack) => (Storable b) => (CVodeMem -> Ptr b -> IO CInt) -> CVodeMem -> IO b
+cvGet getter cvode_mem = do
+  alloca $ \ptr -> do
+    err <- getter cvode_mem ptr
+    when (err /= CV_SUCCESS) $ do
+      error $ "Failure during cvGet"
+    peek ptr
+
+foreign import ccall "CVodeGetEstLocalErrors" cCVodeGetEstLocalErrors :: CVodeMem -> N_Vector -> IO CInt
+
+foreign import ccall "CVodeGetErrWeights" cCVodeGetErrWeights :: CVodeMem -> N_Vector -> IO CInt
+
+foreign import ccall "SUNContext_ClearErrHandlers" cSUNContext_ClearErrHandlers :: SUNContext -> IO CInt
+
+foreign import ccall "N_VGetArrayPointer" cN_VGetArrayPointer :: N_Vector -> IO (Ptr CDouble)

--- a/src/Numeric/Sundials/CVode.hs
+++ b/src/Numeric/Sundials/CVode.hs
@@ -425,11 +425,11 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
 
   flag = CVodeGetNumJacEvals(cvode_mem, &nje);
   check_flag(&flag, "CVodeGetNumJacEvals", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[8] = ncfn;
+  ($vec-ptr:(sunindextype *c_diagnostics))[8] = nje;
 
   flag = CVodeGetNumLinRhsEvals(cvode_mem, &nfeLS);
   check_flag(&flag, "CVodeGetNumLinRhsEvals", 1, report_error);
-  ($vec-ptr:(sunindextype *c_diagnostics))[9] = ncfn;
+  ($vec-ptr:(sunindextype *c_diagnostics))[9] = nfeLS;
 
   /* Clean up and return */
   N_VDestroy(y);          /* Free y vector          */

--- a/src/Numeric/Sundials/Foreign.hsc
+++ b/src/Numeric/Sundials/Foreign.hsc
@@ -2,6 +2,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Numeric.Sundials.Foreign
   ( getDataFromContents
@@ -59,6 +60,20 @@ module Numeric.Sundials.Foreign
   , kVAERNO_7_4_5
   , aRK548L2SA_DIRK_8_4_5
   , mIN_DIRK_NUM
+  , pattern CSC_MAT
+  , pattern ARKODE_MIN_DIRK_NUM
+
+  , pattern CV_NORMAL
+  , pattern CV_ROOT_RETURN
+  , pattern CV_SUCCESS
+  , pattern CV_TOO_CLOSE
+
+  , pattern ARK_NORMAL
+  , pattern ARK_ROOT_RETURN
+  , pattern ARK_SUCCESS
+  , pattern ARK_TOO_CLOSE
+
+  , getContentPtr, getData
   ) where
 
 import           Foreign
@@ -349,3 +364,21 @@ vERNER_8_5_6 :: CInt
 vERNER_8_5_6 = #const ARKODE_VERNER_8_5_6
 fEHLBERG_13_7_8 :: CInt
 fEHLBERG_13_7_8 = #const ARKODE_FEHLBERG_13_7_8
+
+pattern CSC_MAT :: CInt
+pattern CSC_MAT = #const CSC_MAT
+
+pattern CV_NORMAL, CV_SUCCESS, CV_ROOT_RETURN, CV_TOO_CLOSE :: CInt
+pattern CV_NORMAL = #const CV_NORMAL
+pattern CV_SUCCESS = #const CV_SUCCESS
+pattern CV_ROOT_RETURN = #const CV_ROOT_RETURN
+pattern CV_TOO_CLOSE = #const CV_TOO_CLOSE
+
+pattern ARKODE_MIN_DIRK_NUM :: CInt
+pattern ARKODE_MIN_DIRK_NUM = #const ARKODE_MIN_DIRK_NUM
+
+pattern ARK_NORMAL, ARK_SUCCESS, ARK_ROOT_RETURN, ARK_TOO_CLOSE :: CInt
+pattern ARK_NORMAL = #const ARK_NORMAL
+pattern ARK_SUCCESS = #const ARK_SUCCESS
+pattern ARK_ROOT_RETURN = #const ARK_ROOT_RETURN
+pattern ARK_TOO_CLOSE = #const ARK_TOO_CLOSE


### PR DESCRIPTION
This is a work in progress which aims at replacing `inline-c` code by haskell code using the foreign function interface.

Anyway, the costly logic in the `inline-c` is in the `CVode(...)` function, so doing haskell around it will have zero overhead.

On the other hand, it will give us:

- Better error reporting (we will be able to raise exceptions directly in the "main-loop")
- Code should be more readable, mostly error handling, which could be done by wrapping the different cvode function instead of checking for flags.
- It should be better (during the refactor, I started to identify copy/past mistake which leads to incorrect statistics, or codepath which lead to memory leaks)
- We will be able to remove the "interruption logic"
- Will be trivial to hook save / resume progress, and more statistics.

Also, inline-ci is notoriously difficult to work with, errors are not localised or consistent. I expect that this refactor in pure Haskell would allow other members of the team to work on the solver. Also, HLS is difficult to work with inline-c because of the dynamic linkage and template haskell involved.

Right now, I've only started to work on the `cvode` and I'm doing nothing on the arkode code. Maybe we'll remove it (@eltix your point of view). I'm trying to NOT introduce any refactor other than rewritnig the complete `C.block` in haskell in order to recover a working test suite. I'm keeping the "inline-c" code with the hope that, for now, it will ease reviewing. "cleaning" will happen after.