### PR TITLE
fix: remove default error handler

### DIFF
--- a/src/Numeric/Sundials/ARKode.hs
+++ b/src/Numeric/Sundials/ARKode.hs
@@ -173,6 +173,8 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
   if (check_flag(arkode_mem, "ARKStepCreate", 0, report_error)) return 8396;
 
   /* Set the error handler */
+  SUNContext_ClearErrHandlers(sunctx);
+
   SUNErrHandlerFn report_error_new_api = (SUNErrHandlerFn) $fun:(void (*report_error_new_api)(int,const char*, const char*, const char*, int, void*, void *));
   flag = SUNContext_PushErrHandler(sunctx, report_error_new_api, NULL);
   if (check_flag(&flag, "SUNContext_PushErrHandler", 1, report_error)) return 1093;

--- a/src/Numeric/Sundials/CVode.hs
+++ b/src/Numeric/Sundials/CVode.hs
@@ -129,6 +129,7 @@ solveC ptrStop CConsts{..} CVars{..} log_env =
   if (check_flag(&flag, "CVodeInit", 1, report_error)) return(1960);
 
   /* Set the error handler */
+  SUNContext_ClearErrHandlers(sunctx);
 
   SUNErrHandlerFn report_error_new_api = (SUNErrHandlerFn) $fun:(void (*report_error_new_api)(int,const char*, const char*, const char*, int, void*, void *));
   flag = SUNContext_PushErrHandler(sunctx, report_error_new_api, NULL);


### PR DESCRIPTION
Error handling logic uses a "stack" of error and we pushed a new handler in the stack, instead of replacing it.

The default error handler logs everything to stderr, which is a duplicate of what we are doing with the katip logger.