### PR TITLE
feat: completly disable sundials logging

### DIFF
--- a/src/Numeric/Sundials/CVode.hs
+++ b/src/Numeric/Sundials/CVode.hs
@@ -499,15 +499,34 @@ withSUNContext cont = do
   alloca $ \ptr -> do
     let create = do
           errCode <- cSUNContext_Create 0 ptr
+          -- Exception safety here is a bit complex
+          -- Let's assume that nothing will happen here
           when (errCode /= 0) $ do
             errMsg <- cSUNGetErrMsg errCode
             msg <- peekCString errMsg
             error msg
+
+          -- Disable logging
           pure ()
         destroy = cSUNContext_Free ptr
     bracket_ create destroy $ do
       sunctx <- peek ptr
-      cont sunctx
+
+      -- We force disable the logging mecanism
+      -- This stuff SPAMs stderr and generated exessive costs on our
+      -- infrastructure
+      alloca $ \loggerPtr -> do
+        errCode <- cSUNContext_GetLogger sunctx loggerPtr
+        when (loggerPtr == nullPtr || errCode /= 0) $ do
+          error $ "logger is incomplete"
+        logger <- peek loggerPtr
+
+        withCString "/dev/null" $ \devNull -> do
+          cSUNLogger_SetErrorFilename logger devNull
+          cSUNLogger_SetWarningFilename logger devNull
+          cSUNLogger_SetDebugFilename logger devNull
+          cSUNLogger_SetInfoFilename logger devNull
+          cont sunctx
 
 check :: (HasCallStack) => Int -> CInt -> IO ()
 check retCode status
@@ -689,3 +708,16 @@ foreign import ccall "CVodeGetErrWeights" cCVodeGetErrWeights :: CVodeMem -> N_V
 foreign import ccall "SUNContext_ClearErrHandlers" cSUNContext_ClearErrHandlers :: SUNContext -> IO CInt
 
 foreign import ccall "N_VGetArrayPointer" cN_VGetArrayPointer :: N_Vector -> IO (Ptr CDouble)
+
+-- * Logs
+newtype SUNLogger = SUNLogger (Ptr Void)
+  deriving newtype Storable
+
+foreign import ccall "SUNContext_GetLogger" cSUNContext_GetLogger :: SUNContext -> Ptr SUNLogger -> IO CInt
+
+foreign import ccall "SUNLogger_SetErrorFilename" cSUNLogger_SetErrorFilename :: SUNLogger -> CString -> IO ()
+foreign import ccall "SUNLogger_SetWarningFilename" cSUNLogger_SetWarningFilename :: SUNLogger -> CString -> IO ()
+foreign import ccall "SUNLogger_SetInfoFilename" cSUNLogger_SetInfoFilename :: SUNLogger -> CString -> IO ()
+foreign import ccall "SUNLogger_SetDebugFilename" cSUNLogger_SetDebugFilename :: SUNLogger -> CString -> IO ()
+
+


### PR DESCRIPTION
Sundials logging can spam the output with millions of message and the logs messages can only be returned to files.

We disable them for now. Maybe in the future we'll affect a unique file per solving process and then re-read that file in order to output a subset of the relevant logs.

Note: code is duplicated between ARKode and CVode, another WIP MR is currently trying to factorize this. This is an orthogonal work, so we don't bother too much right now.