### PR TITLE
fix(ida): correct values at t=0

### DIFF
--- a/src/Numeric/Sundials/IDA.hs
+++ b/src/Numeric/Sundials/IDA.hs
@@ -177,6 +177,14 @@ solveC CConsts {..} CVars {..} log_env =
                       res <- cIDACalcIC ida_mem IDA_YA_YDP_INIT (if first_time_event > t0 && not (isInfinite first_time_event) then first_time_event else ti)
                       when (res /= IDA_SUCCESS) $ check (fromIntegral res) res
 
+                      -- Update the initial vector with meaningful values
+                      -- Note: this is surprising that IDA does not seem to
+                      -- override by itself the y and yp values.
+                      --
+                      -- This is important to override 'y' here, because we
+                      -- store it in next block.
+                      cIDAGetConsistentIC ida_mem y yp >>= check 12345432
+
                     -- /* Store initial conditions */
                     VSM.write c_output_mat (0 * (fromIntegral c_dim + 1) + 0) (c_sol_time VS.! 0)
                     let go j
@@ -590,5 +598,7 @@ foreign import ccall "IDAGetEstLocalErrors" cIDAGetEstLocalErrors :: IDAMem -> N
 foreign import ccall "IDAGetErrWeights" cIDAGetErrWeights :: IDAMem -> N_Vector -> IO CInt
 
 foreign import ccall "IDACalcIC" cIDACalcIC :: IDAMem -> CInt -> CDouble -> IO CInt
+
+foreign import ccall "IDAGetConsistentIC" cIDAGetConsistentIC :: IDAMem -> N_Vector -> N_Vector -> IO CInt
 
 foreign import ccall "IDASetId" cIDASetId :: IDAMem -> N_Vector -> IO CInt


### PR DESCRIPTION
This fix is surprising and I don't fully understand it.

I observed that the value at t=0 was not taking into account the correction introduced by `IDACalcIC`, we need to get `IDAGetConsistentIC` to get the correct value (and override `y` and `yp` vector).

Doing this fixs the newly introduced test where we can observe that the fixed value appears correctly in the output vector at t=0.

It is unclear if the fixed value was already taken into account during solving, because when I introduced `IDACalcIC`, I got result (e.g. solving was able to get better results).