### PR TITLE
fix: add tests for unsatisfyable constraints in IDA

### DIFF
--- a/src/Numeric/Sundials/ARKode.hs
+++ b/src/Numeric/Sundials/ARKode.hs
@@ -34,8 +34,6 @@ import Numeric.Sundials.Foreign
 import Text.Printf (printf)
 import Data.Vector.Mutable (RealWorld)
 import Data.Coerce (coerce)
-import Data.IORef (readIORef, newIORef, writeIORef, IORef)
-
 -- | Available methods for ARKode
 data ARKMethod
   = SDIRK_2_1_2
@@ -130,7 +128,8 @@ solveC CConsts {..} CVars {..} log_env =
                         --    an event may have eventRecord = False and not be present there.
                         -- \*/
                         t_start = t0,
-                        nb_reinit = 0
+                        nb_reinit = 0,
+                        max_events_reached = False
                       }
                   )
 
@@ -148,8 +147,6 @@ solveC CConsts {..} CVars {..} log_env =
 
             -- /* Initialize data structures */
 
-            -- /* Initialize odeMaxEventsReached to False */
-            odeMaxEventsReached <- newIORef False
             let implicit = c_method >= ARKODE_MIN_DIRK_NUM
 
             -- /* Create serial vector for solution */
@@ -161,7 +158,7 @@ solveC CConsts {..} CVars {..} log_env =
                     | not implicit = \c_rhs -> withARKStepCreate c_rhs nullFunPtr
                     | otherwise = \c_rhs -> withARKStepCreate nullFunPtr c_rhs
               withArkStep c_rhs t0 y sunctx 8396 $ \cvode_mem -> do
-                let getDiagnosticsCallback state = getDiagnostics cvode_mem state c_method c_n_event_specs odeMaxEventsReached
+                let getDiagnosticsCallback state = getDiagnostics cvode_mem state c_method c_n_event_specs
                 -- /* Set the error handler */
                 setErrorHandler sunctx c_report_error
 
@@ -422,7 +419,7 @@ solveC CConsts {..} CVars {..} log_env =
                               if (fromIntegral s.event_ind >= c_max_events)
                                 then do
                                   debug ("Reached max_events; returning")
-                                  liftIO $ writeIORef odeMaxEventsReached True
+                                  modify $ \s -> s {max_events_reached = True }
                                   pure 1
                                 else pure stop_solver
                             when (stop_solver /= 0) $ do
@@ -456,16 +453,16 @@ solveC CConsts {..} CVars {..} log_env =
                       Left (ReturnCodeWithMessage _message c)
                         | c == fromIntegral ARK_SUCCESS -> pure (ARK_SUCCESS, mempty)
                         | otherwise -> pure $ (fromIntegral c, mempty)
-                      Right finalState -> end cvode_mem odeMaxEventsReached finalState
-                      Left (Break finalState) -> end cvode_mem odeMaxEventsReached finalState
-                      Left (Finish finalState) -> end cvode_mem odeMaxEventsReached finalState
+                      Right finalState -> end cvode_mem finalState
+                      Left (Break finalState) -> end cvode_mem finalState
+                      Left (Finish finalState) -> end cvode_mem finalState
   where
-    end cvode_mem odeMaxEventsReached finalState = do
-      diagnostics <- getDiagnostics cvode_mem finalState c_method c_n_event_specs odeMaxEventsReached
+    end cvode_mem finalState = do
+      diagnostics <- getDiagnostics cvode_mem finalState c_method c_n_event_specs
       pure (ARK_SUCCESS, diagnostics)
 
-getDiagnostics :: ARKodeMem -> LoopState -> CInt -> CInt -> IORef Bool -> IO SundialsDiagnostics
-getDiagnostics cvode_mem loopState c_method c_n_event_specs odeMaxEventsReached = do
+getDiagnostics :: ARKodeMem -> LoopState -> CInt -> CInt -> IO SundialsDiagnostics
+getDiagnostics cvode_mem loopState c_method c_n_event_specs = do
       -- /* Get some final statistics on how the solve progressed */
       nst <- cvGet cARKodeGetNumSteps cvode_mem
 
@@ -498,8 +495,6 @@ getDiagnostics cvode_mem loopState c_method c_n_event_specs odeMaxEventsReached 
         else do
           pure (0, 0, 0)
 
-      maxEventReached <- readIORef odeMaxEventsReached
-
       -- It is surprising but this command fails with ARKode only when no root
       -- are set
       gevals <- if c_n_event_specs /= 0
@@ -517,7 +512,7 @@ getDiagnostics cvode_mem loopState c_method c_n_event_specs odeMaxEventsReached 
              (fromIntegral $ ncfn)
              (fromIntegral $ nje)
              (fromIntegral $ nfeLS)
-             maxEventReached
+             (max_events_reached loopState)
              (fromIntegral gevals)
              (nb_reinit loopState)
 

--- a/src/Numeric/Sundials/ARKode.hs
+++ b/src/Numeric/Sundials/ARKode.hs
@@ -461,9 +461,6 @@ solveC CConsts {..} CVars {..} log_env =
                       Left (Finish finalState) -> end cvode_mem odeMaxEventsReached finalState
   where
     end cvode_mem odeMaxEventsReached finalState = do
-      -- /* The number of actual roots we found */
-      VSM.write c_n_events 0 (fromIntegral finalState.event_ind)
-
       diagnostics <- getDiagnostics cvode_mem finalState c_method c_n_event_specs odeMaxEventsReached
       pure (ARK_SUCCESS, diagnostics)
 

--- a/src/Numeric/Sundials/Bindings/Sundials.hs
+++ b/src/Numeric/Sundials/Bindings/Sundials.hs
@@ -235,7 +235,9 @@ data LoopState = LoopState
     event_ind :: {-# UNPACK #-} !Int,
     t_start :: {-# UNPACK #-} !CDouble,
     -- Count the number of reinit of the solver
-    nb_reinit :: {-# UNPACK #-} !Int
+    nb_reinit :: {-# UNPACK #-} !Int,
+    -- | Did we reached the maximum number of event
+    max_events_reached :: {-# UNPACK #-} !Bool
   }
   deriving (Show)
 

--- a/src/Numeric/Sundials/CVode.hs
+++ b/src/Numeric/Sundials/CVode.hs
@@ -400,8 +400,6 @@ solveC CConsts {..} CVars {..} log_env =
                       Left (Finish finalState) -> end cvode_mem odeMaxEventsReached finalState
   where
     end cvode_mem odeMaxEventsReached finalState = do
-      -- /* The number of actual roots we found */
-      VSM.write c_n_events 0 (fromIntegral finalState.event_ind)
       diagnostics <- getDiagnostics cvode_mem finalState odeMaxEventsReached
       pure (CV_SUCCESS, diagnostics)
 

--- a/src/Numeric/Sundials/CVode.hs
+++ b/src/Numeric/Sundials/CVode.hs
@@ -33,7 +33,6 @@ import Numeric.Sundials.Common
 import Numeric.Sundials.Foreign
 import Text.Printf (printf)
 import Data.Coerce (coerce)
-import Data.IORef (readIORef, newIORef, writeIORef, IORef)
 
 -- | Available methods for CVode
 data CVMethod
@@ -81,7 +80,8 @@ solveC CConsts {..} CVars {..} log_env =
                         --    an event may have eventRecord = False and not be present there.
                         -- \*/
                         t_start = t0,
-                        nb_reinit = 0
+                        nb_reinit = 0,
+                        max_events_reached = False
                       }
                   )
 
@@ -99,9 +99,6 @@ solveC CConsts {..} CVars {..} log_env =
 
             -- /* Initialize data structures */
 
-            -- /* Initialize odeMaxEventsReached to False */
-            odeMaxEventsReached <- newIORef False
-
             -- /* Create serial vector for solution */
             withNVector_Serial c_dim sunctx 6896 $ \y -> do
               -- /* Specify initial condition */
@@ -109,7 +106,7 @@ solveC CConsts {..} CVars {..} log_env =
 
               -- // NB: Uses the Newton solver by default
               withCVodeMem c_method sunctx 8396 $ \cvode_mem -> do
-                let getDiagnosticsCallback loopState = getDiagnostics cvode_mem loopState odeMaxEventsReached
+                let getDiagnosticsCallback loopState = getDiagnostics cvode_mem loopState
                 cCVodeInit cvode_mem c_rhs t0 y >>= check 1960
 
                 -- /* Set the error handler */
@@ -365,7 +362,7 @@ solveC CConsts {..} CVars {..} log_env =
                               if (fromIntegral s.event_ind >= c_max_events)
                                 then do
                                   debug ("Reached max_events; returning")
-                                  liftIO $ writeIORef odeMaxEventsReached True
+                                  modify $ \s -> s {max_events_reached = True }
                                   pure 1
                                 else pure stop_solver
                             when (stop_solver /= 0) $ do
@@ -395,16 +392,16 @@ solveC CConsts {..} CVars {..} log_env =
                       Left (ReturnCodeWithMessage _message c)
                         | c == fromIntegral IDA_SUCCESS -> pure (IDA_SUCCESS, mempty)
                         | otherwise -> pure $ (fromIntegral c, mempty)
-                      Right finalState -> end cvode_mem odeMaxEventsReached finalState
-                      Left (Break finalState) -> end cvode_mem odeMaxEventsReached finalState
-                      Left (Finish finalState) -> end cvode_mem odeMaxEventsReached finalState
+                      Right finalState -> end cvode_mem finalState
+                      Left (Break finalState) -> end cvode_mem finalState
+                      Left (Finish finalState) -> end cvode_mem finalState
   where
-    end cvode_mem odeMaxEventsReached finalState = do
-      diagnostics <- getDiagnostics cvode_mem finalState odeMaxEventsReached
+    end cvode_mem finalState = do
+      diagnostics <- getDiagnostics cvode_mem finalState
       pure (CV_SUCCESS, diagnostics)
 
-getDiagnostics :: CVodeMem -> LoopState -> IORef Bool -> IO SundialsDiagnostics
-getDiagnostics cvode_mem loopState odeMaxEventsReached = do
+getDiagnostics :: CVodeMem -> LoopState -> IO SundialsDiagnostics
+getDiagnostics cvode_mem loopState = do
       -- /* Get some final statistics on how the solve progressed */
       nst <- cvGet cCVodeGetNumSteps cvode_mem
 
@@ -428,8 +425,6 @@ getDiagnostics cvode_mem loopState odeMaxEventsReached = do
 
       nfeLS <- cvGet cCVodeGetNumLinRhsEvals cvode_mem
 
-      maxEventReached <- readIORef odeMaxEventsReached
-
       gevals <- cvGet cCVodeGetNumGEvals cvode_mem
 
       let diagnostics = SundialsDiagnostics
@@ -443,7 +438,7 @@ getDiagnostics cvode_mem loopState odeMaxEventsReached = do
              (fromIntegral $ ncfn)
              (fromIntegral $ nje)
              (fromIntegral $ nfeLS)
-             maxEventReached
+             (max_events_reached loopState)
              (fromIntegral gevals)
              (nb_reinit loopState)
       pure diagnostics

--- a/src/Numeric/Sundials/Common.hs
+++ b/src/Numeric/Sundials/Common.hs
@@ -32,8 +32,6 @@ data CVars vec = CVars
   , c_event_time :: vec CDouble
     -- ^ For each event occurrence, this indicates the time of the
     -- occurrence. Size: max_num_events.
-  , c_n_events :: vec CInt
-    -- ^ Vector of size 1 that gives the total number of events occurred.
   , c_n_rows :: vec CInt
     -- ^ The total number of rows in the output matrix.
   , c_output_mat :: vec CDouble
@@ -60,7 +58,6 @@ allocateCVars OdeProblem{..} = do
   c_event_index <- VSM.new odeMaxEvents
   c_event_time <- VSM.new odeMaxEvents
   c_actual_event_direction <- VSM.new odeMaxEvents
-  c_n_events <- VSM.new 1
   c_n_rows <- VSM.new 1
   c_local_error <- VSM.new dim
   c_var_weight <- VSM.new dim
@@ -77,7 +74,6 @@ freezeCVars CVars{..} = do
   c_event_index <- VS.unsafeFreeze c_event_index
   c_event_time <- VS.unsafeFreeze c_event_time
   c_actual_event_direction <- VS.unsafeFreeze c_actual_event_direction
-  c_n_events <- VS.unsafeFreeze c_n_events
   c_n_rows <- VS.unsafeFreeze c_n_rows
   c_output_mat <- VS.unsafeFreeze c_output_mat
   c_local_error <- VS.unsafeFreeze c_local_error

--- a/src/Numeric/Sundials/IDA.hs
+++ b/src/Numeric/Sundials/IDA.hs
@@ -33,7 +33,6 @@ import Numeric.Sundials.Foreign
 import Text.Printf (printf)
 import Data.Coerce (coerce)
 import Data.Bool (bool)
-import Data.IORef (newIORef, writeIORef, readIORef, IORef)
 
 -- | Available methods for IDA
 data IDAMethod = IDADefault
@@ -79,7 +78,8 @@ solveC CConsts {..} CVars {..} log_env =
                         --    an event may have eventRecord = False and not be present there.
                         -- \*/
                         t_start = t0,
-                        nb_reinit = 0
+                        nb_reinit = 0,
+                        max_events_reached = False
                       }
                   )
 
@@ -97,9 +97,6 @@ solveC CConsts {..} CVars {..} log_env =
 
             -- /* Initialize data structures */
 
-            -- /* Initialize odeMaxEventsReached to False */
-            odeMaxEventsReached <- newIORef False
-
             -- /* Create serial vector for solution */
             withNVector_Serial c_dim sunctx 6896 $ \y -> withNVector_Serial c_dim sunctx 6896 $ \yp -> withNVector_Serial c_dim sunctx 6896 $ \ids -> do
               -- /* Specify initial condition */
@@ -107,7 +104,7 @@ solveC CConsts {..} CVars {..} log_env =
               VS.imapM_ (\i v -> cNV_Ith_S yp i v) c_init_differentials
 
               withIDACreate sunctx 8396 $ \ida_mem -> do
-                let getDiagnosticsCallback state = getDiagnostics ida_mem state odeMaxEventsReached
+                let getDiagnosticsCallback state = getDiagnostics ida_mem state
                 cIDAInit ida_mem c_ida_res t0 y yp >>= check 1234
                 -- /* Set the error handler */
                 setErrorHandler sunctx c_report_error
@@ -392,7 +389,7 @@ solveC CConsts {..} CVars {..} log_env =
                               if (fromIntegral s.event_ind >= c_max_events)
                                 then do
                                   debug ("Reached max_events; returning")
-                                  liftIO $ writeIORef odeMaxEventsReached True
+                                  modify $ \s -> s {max_events_reached = True }
                                   pure 1
                                 else pure stop_solver
                             when (stop_solver /= 0) $ do
@@ -424,17 +421,17 @@ solveC CConsts {..} CVars {..} log_env =
                       Left (ReturnCodeWithMessage _message c)
                         | c == fromIntegral IDA_SUCCESS -> pure (IDA_SUCCESS, mempty)
                         | otherwise -> pure $ (fromIntegral c, mempty)
-                      Right finalState -> end ida_mem odeMaxEventsReached finalState
-                      Left (Break finalState) -> end ida_mem odeMaxEventsReached finalState
-                      Left (Finish finalState) -> end ida_mem odeMaxEventsReached finalState
+                      Right finalState -> end ida_mem finalState
+                      Left (Break finalState) -> end ida_mem finalState
+                      Left (Finish finalState) -> end ida_mem finalState
   where
-    end cvode_mem odeMaxEventsReached finalState = do
-      diagnostics <- getDiagnostics cvode_mem finalState odeMaxEventsReached
+    end cvode_mem finalState = do
+      diagnostics <- getDiagnostics cvode_mem finalState
       pure (IDA_SUCCESS, diagnostics)
 
 
-getDiagnostics :: IDAMem -> LoopState -> IORef Bool -> IO SundialsDiagnostics
-getDiagnostics cvode_mem loopState odeMaxEventsReached = do
+getDiagnostics :: IDAMem -> LoopState -> IO SundialsDiagnostics
+getDiagnostics cvode_mem loopState = do
       -- /* Get some final statistics on how the solve progressed */
       nst <- cvGet cIDAGetNumSteps cvode_mem
 
@@ -461,8 +458,6 @@ getDiagnostics cvode_mem loopState odeMaxEventsReached = do
 
       gevals <- cvGet cIDAGetNumGEvals cvode_mem
 
-      maxEventReached <- readIORef odeMaxEventsReached
-
       let diagnostics = SundialsDiagnostics
              (fromIntegral $ nst)
              (fromIntegral $ nst_a)
@@ -474,7 +469,7 @@ getDiagnostics cvode_mem loopState odeMaxEventsReached = do
              (fromIntegral $ ncfn)
              (fromIntegral $ nje)
              (fromIntegral $ nfeLS)
-             maxEventReached
+             (loopState.max_events_reached)
              (fromIntegral gevals)
              (nb_reinit loopState)
       pure diagnostics

--- a/src/Numeric/Sundials/IDA.hs
+++ b/src/Numeric/Sundials/IDA.hs
@@ -429,9 +429,6 @@ solveC CConsts {..} CVars {..} log_env =
                       Left (Finish finalState) -> end ida_mem odeMaxEventsReached finalState
   where
     end cvode_mem odeMaxEventsReached finalState = do
-      -- /* The number of actual roots we found */
-      VSM.write c_n_events 0 (fromIntegral finalState.event_ind)
-
       diagnostics <- getDiagnostics cvode_mem finalState odeMaxEventsReached
       pure (IDA_SUCCESS, diagnostics)
 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -357,7 +357,7 @@ idaTests = testGroup "IDASolver" $ [
        -- x - 2 = 0 => x = 2
        VS.fromList [2.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0]
       ]
-  ,testCase "behaves propertly on impossible constraint" $ do
+  ,testCase "behaves properly on impossible constraint" $ do
     -- The system is x(0) = 0, dx/dt = 1, hence x is growing
     -- I do have an algebraic constraint, x + abs(y) = 0. Hence it can be
     -- satisfied at t=0, but not after.
@@ -385,7 +385,7 @@ idaTests = testGroup "IDASolver" $ [
     -- Hence ln(y) = -x
     --       y = exp(-x)
     --
-    -- This can be satisfyied. However if y(0) = 0, the first evaluation of the
+    -- This can be satisfied. However if y(0) = 0, the first evaluation of the
     -- algebraic gives -inf. It should either fail OR fix the value of y(0) = 1
     --
     -- It actually fails, which is a good news.

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -357,6 +357,54 @@ idaTests = testGroup "IDASolver" $ [
        -- x - 2 = 0 => x = 2
        VS.fromList [2.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0]
       ]
+  ,testCase "behaves propertly on impossible constraint" $ do
+    -- The system is x(0) = 0, dx/dt = 1, hence x is growing
+    -- I do have an algebraic constraint, x + abs(y) = 0. Hence it can be
+    -- satisfied at t=0, but not after.
+    --
+    -- I want to check that the solver is failing, hence pattern match on Left
+    Left e <- runKatipT ?log_env $ solve (defaultOpts (IDAMethod IDADefault)) $ emptyOdeProblem
+                  { 
+                    odeFunctions = ResidualProblemFunctions ResidualFunctions {
+                              odeResidual = OdeResidualHaskell $ \_t y yp -> pure ([
+                                  yp VS.! 0 - 1,
+                                  y VS.! 0 + abs(y VS.! 1)
+                                  ])
+                            , odeDifferentials = VS.fromList [1.0, 0.0]
+                            , odeInitialDifferentials = VS.fromList [50, 100]
+                              }
+                  , odeJacobian = Nothing
+                  , odeInitCond = [0, 123]
+                  , odeSolTimes = VS.fromList [0..10]
+                  , odeTolerances = defaultTolerances { absTolerances = Left 1e-12 }
+                  }
+    pure ()
+  ,testCase "infinity in constraint" $ do
+    -- The system is x(0) = 0, dx/dt = 1, hence x is growing
+    -- I do have an algebraic constraint, x + ln(y) = 0
+    -- Hence ln(y) = -x
+    --       y = exp(-x)
+    --
+    -- This can be satisfyied. However if y(0) = 0, the first evaluation of the
+    -- algebraic gives -inf. It should either fail OR fix the value of y(0) = 1
+    --
+    -- It actually fails, which is a good news.
+    Left e <- runKatipT ?log_env $ solve (defaultOpts (IDAMethod IDADefault)) $ emptyOdeProblem
+                  { 
+                    odeFunctions = ResidualProblemFunctions ResidualFunctions {
+                              odeResidual = OdeResidualHaskell $ \_t y yp -> pure ([
+                                  yp VS.! 0 - 1,
+                                  y VS.! 0 + log(y VS.! 1)
+                                  ])
+                            , odeDifferentials = VS.fromList [1.0, 0.0]
+                            , odeInitialDifferentials = VS.fromList [0.0, 0.0]
+                              }
+                  , odeJacobian = Nothing
+                  , odeInitCond = [0, 0]
+                  , odeSolTimes = VS.fromList [0..10]
+                  , odeTolerances = defaultTolerances { absTolerances = Left 1e-12 }
+                  }
+    pure ()
  ]
 
 


### PR DESCRIPTION
I wanted these tests to fail instead of infinite looping.

And I observed that it failed correctly, but with an uncaught exception, which explains the infinite loop we observe at novainsilico: the job failing is repetitively retried on production because the exception is not listed as "reproducible" and hence we retry.

This MR changes:

- Add tests for IDA initial conditions (one test which fails immediatly and one which cannot solve the condition at t > 0)
- Refactor the termination logic by using the same function for all solver
- Wrap the solver init with the termination logic, so error at initialisation are not propagated as exception, but instead caught by the solver and returned as a `Left`.