### PR TITLE
Ida event record and t0

### DIFF
--- a/src/Numeric/Sundials/IDA.hs
+++ b/src/Numeric/Sundials/IDA.hs
@@ -360,7 +360,8 @@ solveC CConsts {..} CVars {..} log_env =
                               -- it would make sense to use "next_stop_time", however this will sometimes fail with
                               -- "tout1 too close to t0 to attempt initial condition calculation"
                               -- so we use "next_stop_time * 1.1" instead which is highly questionable but seems to work in practice...
-                              liftIO $ cIDACalcIC ida_mem IDA_YA_YDP_INIT (next_stop_time * 1.1) >>= check 5220
+                              -- We also special case if the next stop time is equal 0, we set something difference (because 0 * 1.1 is still 0)
+                              liftIO $ cIDACalcIC ida_mem IDA_YA_YDP_INIT (if next_stop_time /= 0 then next_stop_time * 1.1 else 1) >>= check 5220
 
                               -- Update the initial vector with meaningful values
                               -- Note: this is surprising that IDA does not seem to

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -415,6 +415,47 @@ idaTests = testGroup "IDASolver" $ [
         -- Y. See how Y(5) = 6, then 12 after event
         VS.fromList [1, 2, 3, 4, 5,                         6, 12,       14, 16, 18, 20, 22]
         ]
+  ,testCase "algebraic event at t=0" $ do
+    -- This ensures that when an event fires at t=0, the solver do not crash with algebraic rules
+    let
+      update :: Double -> Vector Double -> Vector Double
+      update _t y = y VS.// [(0, -10)]
+
+    (time_ev_spec, time_ev_handler) <- mkTimeEvents
+      [ (0.0, update, False, True)
+      ]
+    Right r <- runKatipT ?log_env $ solve (defaultOpts (IDAMethod IDADefault)) $ emptyOdeProblem
+                  { 
+                    odeFunctions = ResidualProblemFunctions ResidualFunctions {
+                              odeResidual = OdeResidualHaskell $ \_t y yp -> pure ([
+                                  -- dx/dt - 1 = 0
+                                  yp VS.! 0 - 1,
+                                  --  y - x = 0
+                                  y VS.! 1 - y VS.! 0
+                                  ])
+                            , odeDifferentials = VS.fromList [1, 0]
+                            , odeInitialDifferentials = VS.fromList [0, 0]
+                              }
+                  , odeJacobian = Nothing
+                  , odeInitCond = [1, 1]
+                  , odeSolTimes = VS.fromList [0..2]
+                  , odeTolerances = defaultTolerances { absTolerances = Left 1e-12 }
+                  , odeEventHandler = time_ev_handler
+                  , odeTimeBasedEvents = time_ev_spec
+                  }
+
+    let
+      round' :: Double -> Integer -> Double
+      round' num sg = (fromIntegral @Int . round $ num * f) / f
+        where f = 10^sg
+    fromColumns (fmap (VS.map (\x -> round' x 2)) (
+      actualTimeGrid r :
+      toColumns (solutionMatrix r))
+     ) @?=  fromColumns [
+         VS.fromList [0.0, 0.0, 1.0, 2.0],
+         VS.fromList [1.0, -10.0, -9.0, -8.0],
+         VS.fromList [1.0, -10.0, -9.0, -8.0]
+        ]
   ,testCase "behaves properly on impossible constraint" $ do
     -- The system is x(0) = 0, dx/dt = 1, hence x is growing
     -- I do have an algebraic constraint, x + abs(y) = 0. Hence it can be

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -462,7 +462,7 @@ idaTests = testGroup "IDASolver" $ [
     -- satisfied at t=0, but not after.
     --
     -- I want to check that the solver is failing, hence pattern match on Left
-    Left e <- runKatipT ?log_env $ solve (defaultOpts (IDAMethod IDADefault)) $ emptyOdeProblem
+    Left _ <- runKatipT ?log_env $ solve (defaultOpts (IDAMethod IDADefault)) $ emptyOdeProblem
                   { 
                     odeFunctions = ResidualProblemFunctions ResidualFunctions {
                               odeResidual = OdeResidualHaskell $ \_t y yp -> pure ([
@@ -488,7 +488,7 @@ idaTests = testGroup "IDASolver" $ [
     -- algebraic gives -inf. It should either fail OR fix the value of y(0) = 1
     --
     -- It actually fails, which is a good news.
-    Left e <- runKatipT ?log_env $ solve (defaultOpts (IDAMethod IDADefault)) $ emptyOdeProblem
+    Left _ <- runKatipT ?log_env $ solve (defaultOpts (IDAMethod IDADefault)) $ emptyOdeProblem
                   { 
                     odeFunctions = ResidualProblemFunctions ResidualFunctions {
                               odeResidual = OdeResidualHaskell $ \_t y yp -> pure ([


### PR DESCRIPTION
Close https://github.com/novainsilico/hmatrix-sundials/issues/38:

1. It adds two unit tests to ensure that after an event involving algebairc rules, the solver do not crash (especially if the event happen at t=0) and that the modified values are correctly recorded.
2. It fix at crash when event happen at t=0 by ensuring that `IDACalcIC` is called with a "next time" in the future.
3. It correctly records algebraic values modified by event (by moving the recomputation with `IDACalcIC` before storing the value AND by updating the value with `IDAGetConsistentIC`